### PR TITLE
feat(auth): Implement login endpoint with JWT, validation, and service

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,14 +3,14 @@ version: '3.8'
 services:
   # PostgreSQL Database
   postgres:
-    image: postgres:15-alpine
+    image: postgres:16-alpine
     container_name: allertify-postgres
     environment:
       POSTGRES_DB: allertify
       POSTGRES_USER: allertify
       POSTGRES_PASSWORD: 12345678
     ports:
-      - "5437:5437"
+      - "127.0.0.1:5437:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -24,7 +24,7 @@ services:
     image: redis:7-alpine
     container_name: allertify-redis
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6371:6379"
     volumes:
       - redis_data:/data
     healthcheck:
@@ -39,15 +39,21 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: allertify-be
+    env_file:
+      - .env
     environment:
-      NODE_ENV: production
+      NODE_ENV: development
       PORT: 3000
-      DATABASE_URL: postgresql://allertify:12345678@postgres:5437/allertify
+      DATABASE_URL: postgresql://allertify:12345678@postgres:5432/allertify
       JWT_ACCESS_SECRET: 4lL3rT1FFy_BE
       JWT_REFRESH_SECRET: 4lL3rT1FFy_BE
       REDIS_URL: redis://redis:6379
+      # Cloudinary Configuration
+      CLOUDINARY_CLOUD_NAME: ${CLOUDINARY_CLOUD_NAME}
+      CLOUDINARY_API_KEY: ${CLOUDINARY_API_KEY}
+      CLOUDINARY_API_SECRET: ${CLOUDINARY_API_SECRET}
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3109:3000"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+echo "⏳ Waiting DB..."
+sleep 3
+
+echo "🔧 Prisma generate..."
+npx prisma generate
+
+echo "🔄 Migrate deploy..."
+npx prisma migrate deploy
+
+echo "🌱 Seeding (idempotent)..."
+npm run -s prisma:seed || npx prisma db seed || true
+
+echo "🚀 Starting app..."
+exec node dist/index.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@types/jest": "^29.5.8",
         "@types/jsonwebtoken": "^9.0.5",
         "@types/node": "^24.2.1",
+        "@types/nodemailer": "^7.0.0",
         "@types/supertest": "^2.0.16",
         "@typescript-eslint/eslint-plugin": "^8.39.0",
         "@typescript-eslint/parser": "^8.39.0",
@@ -126,6 +127,720 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sesv2": {
+      "version": "3.864.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.864.0.tgz",
+      "integrity": "sha512-pwn4/3bs7ccucS9sYpMbzptEhEFQQy8TXtmKNzmyY7OIDBGTiJrxsWYDTULO4nxsMmGXi39mSEowlK4QUCyC+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.864.0",
+        "@aws-sdk/credential-provider-node": "3.864.0",
+        "@aws-sdk/middleware-host-header": "3.862.0",
+        "@aws-sdk/middleware-logger": "3.862.0",
+        "@aws-sdk/middleware-recursion-detection": "3.862.0",
+        "@aws-sdk/middleware-user-agent": "3.864.0",
+        "@aws-sdk/region-config-resolver": "3.862.0",
+        "@aws-sdk/signature-v4-multi-region": "3.864.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-endpoints": "3.862.0",
+        "@aws-sdk/util-user-agent-browser": "3.862.0",
+        "@aws-sdk/util-user-agent-node": "3.864.0",
+        "@smithy/config-resolver": "^4.1.5",
+        "@smithy/core": "^3.8.0",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/hash-node": "^4.0.5",
+        "@smithy/invalid-dependency": "^4.0.5",
+        "@smithy/middleware-content-length": "^4.0.5",
+        "@smithy/middleware-endpoint": "^4.1.18",
+        "@smithy/middleware-retry": "^4.1.19",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/middleware-stack": "^4.0.5",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.26",
+        "@smithy/util-defaults-mode-node": "^4.0.26",
+        "@smithy/util-endpoints": "^3.0.7",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-retry": "^4.0.7",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.864.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.864.0.tgz",
+      "integrity": "sha512-THiOp0OpQROEKZ6IdDCDNNh3qnNn/kFFaTSOiugDpgcE5QdsOxh1/RXq7LmHpTJum3cmnFf8jG59PHcz9Tjnlw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.864.0",
+        "@aws-sdk/middleware-host-header": "3.862.0",
+        "@aws-sdk/middleware-logger": "3.862.0",
+        "@aws-sdk/middleware-recursion-detection": "3.862.0",
+        "@aws-sdk/middleware-user-agent": "3.864.0",
+        "@aws-sdk/region-config-resolver": "3.862.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-endpoints": "3.862.0",
+        "@aws-sdk/util-user-agent-browser": "3.862.0",
+        "@aws-sdk/util-user-agent-node": "3.864.0",
+        "@smithy/config-resolver": "^4.1.5",
+        "@smithy/core": "^3.8.0",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/hash-node": "^4.0.5",
+        "@smithy/invalid-dependency": "^4.0.5",
+        "@smithy/middleware-content-length": "^4.0.5",
+        "@smithy/middleware-endpoint": "^4.1.18",
+        "@smithy/middleware-retry": "^4.1.19",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/middleware-stack": "^4.0.5",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.26",
+        "@smithy/util-defaults-mode-node": "^4.0.26",
+        "@smithy/util-endpoints": "^3.0.7",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-retry": "^4.0.7",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.864.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.864.0.tgz",
+      "integrity": "sha512-LFUREbobleHEln+Zf7IG83lAZwvHZG0stI7UU0CtwyuhQy5Yx0rKksHNOCmlM7MpTEbSCfntEhYi3jUaY5e5lg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/xml-builder": "3.862.0",
+        "@smithy/core": "^3.8.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/signature-v4": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-utf8": "^4.0.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.864.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.864.0.tgz",
+      "integrity": "sha512-StJPOI2Rt8UE6lYjXUpg6tqSZaM72xg46ljPg8kIevtBAAfdtq9K20qT/kSliWGIBocMFAv0g2mC0hAa+ECyvg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.864.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.864.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.864.0.tgz",
+      "integrity": "sha512-E/RFVxGTuGnuD+9pFPH2j4l6HvrXzPhmpL8H8nOoJUosjx7d4v93GJMbbl1v/fkDLqW9qN4Jx2cI6PAjohA6OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.864.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-stream": "^4.2.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.864.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.864.0.tgz",
+      "integrity": "sha512-PlxrijguR1gxyPd5EYam6OfWLarj2MJGf07DvCx9MAuQkw77HBnsu6+XbV8fQriFuoJVTBLn9ROhMr/ROAYfUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.864.0",
+        "@aws-sdk/credential-provider-env": "3.864.0",
+        "@aws-sdk/credential-provider-http": "3.864.0",
+        "@aws-sdk/credential-provider-process": "3.864.0",
+        "@aws-sdk/credential-provider-sso": "3.864.0",
+        "@aws-sdk/credential-provider-web-identity": "3.864.0",
+        "@aws-sdk/nested-clients": "3.864.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/credential-provider-imds": "^4.0.7",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.864.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.864.0.tgz",
+      "integrity": "sha512-2BEymFeXURS+4jE9tP3vahPwbYRl0/1MVaFZcijj6pq+nf5EPGvkFillbdBRdc98ZI2NedZgSKu3gfZXgYdUhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.864.0",
+        "@aws-sdk/credential-provider-http": "3.864.0",
+        "@aws-sdk/credential-provider-ini": "3.864.0",
+        "@aws-sdk/credential-provider-process": "3.864.0",
+        "@aws-sdk/credential-provider-sso": "3.864.0",
+        "@aws-sdk/credential-provider-web-identity": "3.864.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/credential-provider-imds": "^4.0.7",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.864.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.864.0.tgz",
+      "integrity": "sha512-Zxnn1hxhq7EOqXhVYgkF4rI9MnaO3+6bSg/tErnBQ3F8kDpA7CFU24G1YxwaJXp2X4aX3LwthefmSJHwcVP/2g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.864.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.864.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.864.0.tgz",
+      "integrity": "sha512-UPyPNQbxDwHVGmgWdGg9/9yvzuedRQVF5jtMkmP565YX9pKZ8wYAcXhcYdNPWFvH0GYdB0crKOmvib+bmCuwkw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.864.0",
+        "@aws-sdk/core": "3.864.0",
+        "@aws-sdk/token-providers": "3.864.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.864.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.864.0.tgz",
+      "integrity": "sha512-nNcjPN4SYg8drLwqK0vgVeSvxeGQiD0FxOaT38mV2H8cu0C5NzpvA+14Xy+W6vT84dxgmJYKk71Cr5QL2Oz+rA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.864.0",
+        "@aws-sdk/nested-clients": "3.864.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.862.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.862.0.tgz",
+      "integrity": "sha512-jDje8dCFeFHfuCAxMDXBs8hy8q9NCTlyK4ThyyfAj3U4Pixly2mmzY2u7b7AyGhWsjJNx8uhTjlYq5zkQPQCYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.862.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.862.0.tgz",
+      "integrity": "sha512-N/bXSJznNBR/i7Ofmf9+gM6dx/SPBK09ZWLKsW5iQjqKxAKn/2DozlnE54uiEs1saHZWoNDRg69Ww4XYYSlG1Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.862.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.862.0.tgz",
+      "integrity": "sha512-KVoo3IOzEkTq97YKM4uxZcYFSNnMkhW/qj22csofLegZi5fk90ztUnnaeKfaEJHfHp/tm1Y3uSoOXH45s++kKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.864.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.864.0.tgz",
+      "integrity": "sha512-GjYPZ6Xnqo17NnC8NIQyvvdzzO7dm+Ks7gpxD/HsbXPmV2aEfuFveJXneGW9e1BheSKFff6FPDWu8Gaj2Iu1yg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.864.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-arn-parser": "3.804.0",
+        "@smithy/core": "^3.8.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/signature-v4": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-stream": "^4.2.4",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.864.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.864.0.tgz",
+      "integrity": "sha512-wrddonw4EyLNSNBrApzEhpSrDwJiNfjxDm5E+bn8n32BbAojXASH8W8jNpxz/jMgNkkJNxCfyqybGKzBX0OhbQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.864.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-endpoints": "3.862.0",
+        "@smithy/core": "^3.8.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.864.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.864.0.tgz",
+      "integrity": "sha512-H1C+NjSmz2y8Tbgh7Yy89J20yD/hVyk15hNoZDbCYkXg0M358KS7KVIEYs8E2aPOCr1sK3HBE819D/yvdMgokA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.864.0",
+        "@aws-sdk/middleware-host-header": "3.862.0",
+        "@aws-sdk/middleware-logger": "3.862.0",
+        "@aws-sdk/middleware-recursion-detection": "3.862.0",
+        "@aws-sdk/middleware-user-agent": "3.864.0",
+        "@aws-sdk/region-config-resolver": "3.862.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-endpoints": "3.862.0",
+        "@aws-sdk/util-user-agent-browser": "3.862.0",
+        "@aws-sdk/util-user-agent-node": "3.864.0",
+        "@smithy/config-resolver": "^4.1.5",
+        "@smithy/core": "^3.8.0",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/hash-node": "^4.0.5",
+        "@smithy/invalid-dependency": "^4.0.5",
+        "@smithy/middleware-content-length": "^4.0.5",
+        "@smithy/middleware-endpoint": "^4.1.18",
+        "@smithy/middleware-retry": "^4.1.19",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/middleware-stack": "^4.0.5",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.26",
+        "@smithy/util-defaults-mode-node": "^4.0.26",
+        "@smithy/util-endpoints": "^3.0.7",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-retry": "^4.0.7",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.862.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.862.0.tgz",
+      "integrity": "sha512-VisR+/HuVFICrBPY+q9novEiE4b3mvDofWqyvmxHcWM7HumTz9ZQSuEtnlB/92GVM3KDUrR9EmBHNRrfXYZkcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.864.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.864.0.tgz",
+      "integrity": "sha512-w2HIn/WIcUyv1bmyCpRUKHXB5KdFGzyxPkp/YK5g+/FuGdnFFYWGfcO8O+How4jwrZTarBYsAHW9ggoKvwr37w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.864.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/signature-v4": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.864.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.864.0.tgz",
+      "integrity": "sha512-gTc2QHOBo05SCwVA65dUtnJC6QERvFaPiuppGDSxoF7O5AQNK0UR/kMSenwLqN8b5E1oLYvQTv3C1idJLRX0cg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.864.0",
+        "@aws-sdk/nested-clients": "3.864.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.862.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.862.0.tgz",
+      "integrity": "sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.804.0.tgz",
+      "integrity": "sha512-wmBJqn1DRXnZu3b4EkE6CWnoWMo1ZMvlfkqU5zPz67xx1GMaXlDCchFvKAXMjk4jn/L1O3tKnoFDNsoLV1kgNQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.862.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.862.0.tgz",
+      "integrity": "sha512-eCZuScdE9MWWkHGM2BJxm726MCmWk/dlHjOKvkM0sN1zxBellBMw5JohNss1Z8/TUmnW2gb9XHTOiHuGjOdksA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-endpoints": "^3.0.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.804.0.tgz",
+      "integrity": "sha512-zVoRfpmBVPodYlnMjgVjfGoEZagyRF5IPn3Uo6ZvOZp24chnW/FRstH7ESDHDDRga4z3V+ElUQHKpFDXWyBW5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.862.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.862.0.tgz",
+      "integrity": "sha512-BmPTlm0r9/10MMr5ND9E92r8KMZbq5ltYXYpVcUbAsnB1RJ8ASJuRoLne5F7mB3YMx0FJoOTuSq7LdQM3LgW3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/types": "^4.3.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.864.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.864.0.tgz",
+      "integrity": "sha512-d+FjUm2eJEpP+FRpVR3z6KzMdx1qwxEYDz8jzNKwxYLBBquaBaP/wfoMtMQKAcbrR7aT9FZVZF7zDgzNxUvQlQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.864.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.862.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.862.0.tgz",
+      "integrity": "sha512-6Ed0kmC1NMbuFTEgNmamAUU1h5gShgxL1hBVLbEzUa3trX5aJBz1vU4bXaBTvOYUAnOHtiy1Ml4AMStd6hJnFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1465,6 +2180,615 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.5.tgz",
+      "integrity": "sha512-jcrqdTQurIrBbUm4W2YdLVMQDoL0sA9DTxYd2s+R/y+2U9NLOP7Xf/YqfSg1FZhlZIYEnvk2mwbyvIfdLEPo8g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.5.tgz",
+      "integrity": "sha512-viuHMxBAqydkB0AfWwHIdwf/PRH2z5KHGUzqyRtS/Wv+n3IHI993Sk76VCA7dD/+GzgGOmlJDITfPcJC1nIVIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.8.0.tgz",
+      "integrity": "sha512-EYqsIYJmkR1VhVE9pccnk353xhs+lB6btdutJEtsp7R055haMJp2yE16eSxw8fv+G0WUY6vqxyYOP8kOqawxYQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-stream": "^4.2.4",
+        "@smithy/util-utf8": "^4.0.0",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.7.tgz",
+      "integrity": "sha512-dDzrMXA8d8riFNiPvytxn0mNwR4B3h8lgrQ5UjAGu6T9z/kRg/Xncf4tEQHE/+t25sY8IH3CowcmWi+1U5B1Gw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.1.tgz",
+      "integrity": "sha512-61WjM0PWmZJR+SnmzaKI7t7G0UkkNFboDpzIdzSoy7TByUzlxo18Qlh9s71qug4AY4hlH/CwXdubMtkcNEb/sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/querystring-builder": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-base64": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.5.tgz",
+      "integrity": "sha512-cv1HHkKhpyRb6ahD8Vcfb2Hgz67vNIXEp2vnhzfxLFGRukLCNEA5QdsorbUEzXma1Rco0u3rx5VTqbM06GcZqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.5.tgz",
+      "integrity": "sha512-IVnb78Qtf7EJpoEVo7qJ8BEXQwgC4n3igeJNNKEj/MLYtapnx8A67Zt/J3RXAj2xSO1910zk0LdFiygSemuLow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.5.tgz",
+      "integrity": "sha512-l1jlNZoYzoCC7p0zCtBDE5OBXZ95yMKlRlftooE5jPWQn4YBPLgsp+oeHp7iMHaTGoUdFqmHOPa8c9G3gBsRpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.18.tgz",
+      "integrity": "sha512-ZhvqcVRPZxnZlokcPaTwb+r+h4yOIOCJmx0v2d1bpVlmP465g3qpVSf7wxcq5zZdu4jb0H4yIMxuPwDJSQc3MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.8.0",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-middleware": "^4.0.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.1.19",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.19.tgz",
+      "integrity": "sha512-X58zx/NVECjeuUB6A8HBu4bhx72EoUz+T5jTMIyeNKx2lf+Gs9TmWPNNkH+5QF0COjpInP/xSpJGJ7xEnAklQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/service-error-classification": "^4.0.7",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-retry": "^4.0.7",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.9.tgz",
+      "integrity": "sha512-uAFFR4dpeoJPGz8x9mhxp+RPjo5wW0QEEIPPPbLXiRRWeCATf/Km3gKIVR5vaP8bN1kgsPhcEeh+IZvUlBv6Xg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.5.tgz",
+      "integrity": "sha512-/yoHDXZPh3ocRVyeWQFvC44u8seu3eYzZRveCMfgMOBcNKnAmOvjbL9+Cp5XKSIi9iYA9PECUuW2teDAk8T+OQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.4.tgz",
+      "integrity": "sha512-+UDQV/k42jLEPPHSn39l0Bmc4sB1xtdI9Gd47fzo/0PbXzJ7ylgaOByVjF5EeQIumkepnrJyfx86dPa9p47Y+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.1.1.tgz",
+      "integrity": "sha512-RHnlHqFpoVdjSPPiYy/t40Zovf3BBHc2oemgD7VsVTFFZrU5erFFe0n52OANZZ/5sbshgD93sOh5r6I35Xmpaw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/querystring-builder": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.5.tgz",
+      "integrity": "sha512-R/bswf59T/n9ZgfgUICAZoWYKBHcsVDurAGX88zsiUtOTA/xUAPyiT+qkNCPwFn43pZqN84M4MiUsbSGQmgFIQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.3.tgz",
+      "integrity": "sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.5.tgz",
+      "integrity": "sha512-NJeSCU57piZ56c+/wY+AbAw6rxCCAOZLCIniRE7wqvndqxcKKDOXzwWjrY7wGKEISfhL9gBbAaWWgHsUGedk+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-uri-escape": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.5.tgz",
+      "integrity": "sha512-6SV7md2CzNG/WUeTjVe6Dj8noH32r4MnUeFKZrnVYsQxpGSIcphAanQMayi8jJLZAWm6pdM9ZXvKCpWOsIGg0w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.7.tgz",
+      "integrity": "sha512-XvRHOipqpwNhEjDf2L5gJowZEm5nsxC16pAZOeEcsygdjv9A2jdOh3YoDQvOXBGTsaJk6mNWtzWalOB9976Wlg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.5.tgz",
+      "integrity": "sha512-YVVwehRDuehgoXdEL4r1tAAzdaDgaC9EQvhK0lEbfnbrd0bd5+CTQumbdPryX3J2shT7ZqQE+jPW4lmNBAB8JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.3.tgz",
+      "integrity": "sha512-mARDSXSEgllNzMw6N+mC+r1AQlEBO3meEAkR/UlfAgnMzJUB3goRBWgip1EAMG99wh36MDqzo86SfIX5Y+VEaw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-hex-encoding": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-uri-escape": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.10.tgz",
+      "integrity": "sha512-iW6HjXqN0oPtRS0NK/zzZ4zZeGESIFcxj2FkWed3mcK8jdSdHzvnCKXSjvewESKAgGKAbJRA+OsaqKhkdYRbQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.8.0",
+        "@smithy/middleware-endpoint": "^4.1.18",
+        "@smithy/middleware-stack": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-stream": "^4.2.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+      "integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.5.tgz",
+      "integrity": "sha512-j+733Um7f1/DXjYhCbvNXABV53NyCRRA54C7bNEIxNPs0YjfRxeMKjjgm2jvTYrciZyCjsicHwQ6Q0ylo+NAUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+      "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+      "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
+      "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
+      "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.0.26",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.26.tgz",
+      "integrity": "sha512-xgl75aHIS/3rrGp7iTxQAOELYeyiwBu+eEgAk4xfKwJJ0L8VUjhO2shsDpeil54BOFsqmk5xfdesiewbUY5tKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.0.26",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.26.tgz",
+      "integrity": "sha512-z81yyIkGiLLYVDetKTUeCZQ8x20EEzvQjrqJtb/mXnevLq2+w3XCEWTJ2pMp401b6BkEkHVfXb/cROBpVauLMQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.1.5",
+        "@smithy/credential-provider-imds": "^4.0.7",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.7.tgz",
+      "integrity": "sha512-klGBP+RpBp6V5JbrY2C/VKnHXn3d5V2YrifZbmMY8os7M6m8wdYFoO6w/fe5VkP+YVwrEktW3IWYaSQVNZJ8oQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+      "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.5.tgz",
+      "integrity": "sha512-N40PfqsZHRSsByGB81HhSo+uvMxEHT+9e255S53pfBw/wI6WKDI7Jw9oyu5tJTLwZzV5DsMha3ji8jk9dsHmQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.7.tgz",
+      "integrity": "sha512-TTO6rt0ppK70alZpkjwy+3nQlTiqNfoXja+qwuAchIEAIoSZW8Qyd76dvBv3I5bCpE38APafG23Y/u270NspiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.0.7",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.4.tgz",
+      "integrity": "sha512-vSKnvNZX2BXzl0U2RgCLOwWaAP9x/ddd/XobPK02pCbzRm5s55M53uwb1rl/Ts7RXZvdJZerPkA+en2FDghLuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-hex-encoding": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+      "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
@@ -1678,6 +3002,17 @@
         "undici-types": "~7.10.0"
       }
     },
+    "node_modules/@types/nodemailer": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-7.0.0.tgz",
+      "integrity": "sha512-APKHivjoJ1OyLrlhdJ/QJpnj78OaGSHQ18J12CeOVbffvBgUjqBiIzCW2lnRuwQiLxCpahgMf+T7G2dZBvgeYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@aws-sdk/client-sesv2": "^3.839.0",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
@@ -1754,6 +3089,13 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -2402,6 +3744,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.12.0.tgz",
+      "integrity": "sha512-HcOcTudTeEWgbHh0Y1Tyb6fdeR71m4b/QACf0D4KswGTsNeIJQmg38mRENZPAYPZvGFN3fk3604XbQEPdxXdKg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -3573,6 +4922,25 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -5619,6 +6987,7 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.5.tgz",
       "integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==",
+      "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -6674,6 +8043,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/superagent": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
@@ -7009,6 +8391,13 @@
         "strip-json-comments": "^2.0.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -7144,6 +8533,20 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@prisma/client": "^5.22.0",
         "ai": "^5.0.15",
         "argon2": "^0.31.2",
+        "axios": "^1.11.0",
+        "cloudinary": "^2.7.0",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^5.1.0",
@@ -20,6 +22,8 @@
         "helmet": "^7.1.0",
         "joi": "^17.11.0",
         "jsonwebtoken": "^9.0.2",
+        "multer": "^2.0.2",
+        "nodemailer": "^7.0.5",
         "winston": "^3.11.0"
       },
       "devDependencies": {
@@ -2168,6 +2172,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="
+    },
     "node_modules/aproba": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
@@ -2227,8 +2236,17 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -2467,8 +2485,18 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -2635,6 +2663,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/cloudinary": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-2.7.0.tgz",
+      "integrity": "sha512-qrqDn31+qkMCzKu1GfRpzPNAO86jchcNwEHCUiqvPHNSFqu7FTNF9FuAkBUyvM1CFFgFPu64NT0DyeREwLwK0w==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=9"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2720,7 +2760,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2741,6 +2780,20 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
@@ -2896,7 +2949,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3094,7 +3146,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -3647,11 +3698,29 @@
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
       "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -3667,7 +3736,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3676,7 +3744,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -3992,7 +4059,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -5137,6 +5203,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -5365,7 +5436,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5422,6 +5492,73 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "node_modules/multer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
+      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "mkdirp": "^0.5.6",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.18",
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
+    "node_modules/multer/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/multer/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -5477,6 +5614,14 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.5.tgz",
+      "integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nopt": {
       "version": "5.0.0",
@@ -5919,6 +6064,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5944,6 +6094,16 @@
           "url": "https://opencollective.com/fast-check"
         }
       ]
+    },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
+      }
     },
     "node_modules/qs": {
       "version": "6.14.0",
@@ -6434,6 +6594,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -6887,6 +7055,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+    },
     "node_modules/typescript": {
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
@@ -7144,7 +7317,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4"
       }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "@prisma/client": "^5.22.0",
     "ai": "^5.0.15",
     "argon2": "^0.31.2",
+    "axios": "^1.11.0",
+    "cloudinary": "^2.7.0",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^5.1.0",
@@ -38,6 +40,8 @@
     "helmet": "^7.1.0",
     "joi": "^17.11.0",
     "jsonwebtoken": "^9.0.2",
+    "multer": "^2.0.2",
+    "nodemailer": "^7.0.5",
     "winston": "^3.11.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/jest": "^29.5.8",
     "@types/jsonwebtoken": "^9.0.5",
     "@types/node": "^24.2.1",
+    "@types/nodemailer": "^7.0.0",
     "@types/supertest": "^2.0.16",
     "@typescript-eslint/eslint-plugin": "^8.39.0",
     "@typescript-eslint/parser": "^8.39.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@ai-sdk/google": "^2.0.6",
     "@prisma/client": "^5.22.0",
+    "@types/multer": "^2.0.0",
     "ai": "^5.0.15",
     "argon2": "^0.31.2",
     "axios": "^1.11.0",
@@ -62,6 +63,7 @@
     "prisma": "^5.22.0",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.1",
+    "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.9.2"
   },
@@ -81,5 +83,8 @@
       "!src/**/*.d.ts",
       "!src/index.ts"
     ]
+  },
+  "prisma": {
+    "seed": "node dist/prisma/seed.js"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,10 +28,24 @@ model user {
 
   // Relations
   emergency_contacts emergency_contact[]
-  subscriptions      subscription[]
-  user_allegens      user_allergen[]
-  product_reports    product_report[]
-  product_scans      product_scan[]
+  subscriptions       subscription[]
+  user_allegens       user_allergen[]
+  product_reports     product_report[]
+  product_scans       product_scan[]
+  email_verifications email_verification[]
+}
+
+model email_verification {
+  id               Int        @id @default(autoincrement())
+  user_id          Int 
+  otp_code         String     @db.VarChar(6)
+  otp_code_expired DateTime
+  usedAt           DateTime?
+  createdAt        DateTime   @default(now())
+
+  // Relations
+  user  user  @relation(fields: [user_id], references: [id])
+  @@index([user_id])
 }
 
 model allergen {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,10 +28,11 @@ model user {
 
   // Relations
   emergency_contacts emergency_contact[]
-  subscriptions       subscription[]
-  user_allegens       user_allergen[]
-  product_reports     product_report[]
-  product_scans       product_scan[]
+  subscriptions      subscription[]
+  user_allegens      user_allergen[]
+  product_reports    product_report[]
+  product_scans      product_scan[]
+  daily_scan_usages  daily_scan_usage[]
   email_verifications email_verification[]
 }
 
@@ -145,4 +146,16 @@ model product_scan {
   // Relations
   user     user       @relation(fields: [user_id], references: [id])
   product  product    @relation(fields: [product_id], references: [id])
+}
+
+model daily_scan_usage {
+  id          Int      @id @default(autoincrement())
+  user_id     Int
+  usage_date  DateTime @default(now())
+  scan_count  Int      @default(0)
+  
+  // Relations
+  user        user     @relation(fields: [user_id], references: [id])
+  
+  @@unique([user_id, usage_date])
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,60 @@
+import { PrismaClient } from '@prisma/client';
+import argon2 from 'argon2';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log('🌱 Starting database seeding...');
+
+  // Create default allergens
+  const allergens = [
+    { name: 'Milk', description: 'Dairy products' },
+    { name: 'Eggs', description: 'Chicken eggs and egg products' },
+    { name: 'Fish', description: 'Fish and fish products' },
+    { name: 'Shellfish', description: 'Crustaceans and mollusks' },
+    { name: 'Tree Nuts', description: 'Almonds, walnuts, cashews, etc.' },
+    { name: 'Peanuts', description: 'Peanuts and peanut products' },
+    { name: 'Wheat', description: 'Wheat and wheat products' },
+    { name: 'Soybeans', description: 'Soy and soy products' },
+    { name: 'Sesame', description: 'Sesame seeds and products' },
+  ];
+
+  console.log('Creating allergens...');
+  for (const allergen of allergens) {
+    await prisma.allergen.upsert({
+      where: { name: allergen.name },
+      update: {},
+      create: {
+        ...allergen,
+        is_custom: false,
+      },
+    });
+  }
+
+  // Create admin user
+  const adminPassword = await argon2.hash('AdminPassword123!');
+  const admin = await prisma.user.upsert({
+    where: { email: 'admin@allertify.com' },
+    update: {},
+    create: {
+      email: 'admin@allertify.com',
+      full_name: 'Admin User',
+      password: adminPassword,
+      phone_number: '+6281234567890', // Default phone number for admin
+      is_verified: true, // Admin should be verified by default
+      role: 1,
+    },
+  });
+
+  console.log('✅ Database seeding completed!');
+  console.log(`👤 Admin user created: ${admin.email}`);
+}
+
+main()
+  .catch((e) => {
+    console.error('❌ Seeding failed:', e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -1,0 +1,34 @@
+import { Prisma, PrismaClient } from "@prisma/client";
+import { logger } from "../utils/logger";
+
+class Database {
+    private static instance: PrismaClient;
+
+    public static getInstance(): PrismaClient {
+        if(!Database.instance){
+            Database.instance = new PrismaClient({
+                log: process.env.NODE_ENV === 'development' ? ['query', 'info', 'warn', 'error'] : ['error'],
+            });
+
+            Database.instance.$connect()
+            .then(() => {
+                logger.info('Connected to the database');
+            })
+            .catch((error: Error) => {
+                logger.error('Error connecting to the database', error);
+                process.exit(1);
+       
+            });
+        }
+        return Database.instance;
+    }
+
+    public static async disconnect(): Promise<void> {
+        if(Database.instance){
+            await Database.instance.$disconnect();
+            logger.info('Disconnected from the database');
+        }
+    }
+}
+
+export default Database;

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -1,0 +1,58 @@
+import { Request, Response } from "express";
+import { createUser, verifyOtpAndIssueToken } from "../services/auth.service";
+import { registerSchema, otpSchema } from "../middlewares/auth.validation";
+
+export const registerController = async (req: Request, res: Response) => {
+    const { error, value } = registerSchema.validate(req.body, { abortEarly: false, stripUnknown: true });
+    if(error){
+        return res.status(400).json({ success: false, message: "Validation error", detail: error.details.map(d => d.message) });
+    }
+
+    try{
+        const result = await createUser(value);
+
+        if(result.status === "ALREADY_VERIFIED"){
+            return res.status(409).json({ success: false, message: "Email already registered."});
+        }
+
+        const status = result.status === "REGISTERED" ? 201 : 200;
+        const message = result.status === "REGISTERED" 
+            ? "User registered. OTP sent to your email."
+            : "OTP has been resent to your email."
+        return res.status(status).json({ success: true, message });
+    } catch(err: any){
+        //eslint disable
+        console.error("registerController error:", err);
+        return res.status(500).json({ success: false, message: "Internal server error" });
+    }
+}
+
+export async function verifyOtpController(req: Request, res: Response) {
+    const { error, value } = otpSchema.validate(req.body, { abortEarly: false, stripUnknown: true });
+    if(error){
+        return res.status(400).json({ success: false, message: "Validation error", details: error.details.map(d => d.message) });
+    }
+
+    try {
+        const result = await verifyOtpAndIssueToken(value);
+
+        if(!result.ok){
+            if(result.reason === "USER_NOT_FOUND") return res.status(400).json({ success: false, message: "User not found" });
+            if (result.reason === "OTP_NOT_FOUND_OR_EXPIRED" || result.reason === "OTP_EXPIRED")
+                return res.status(400).json({ success: false, message: "OTP not found or expired" });
+            if (result.reason === "OTP_INVALID") return res.status(400).json({ success: false, message: "Invalid OTP" });
+            return res.status(400).json({ success: false, message: "OTP verification failed" });
+        }
+
+        return res.status(200).json({
+            success: true,
+            message: "Account verified",
+            accessToken: result.accessToken,
+            user: result.user,
+        });
+    } catch (err: any) {
+        //eslint disable
+        console.error("verifyOtpController error:", err);
+        return res.status(500).json({ success: false, message: "Internal server error" });
+    }
+}

--- a/src/controllers/scan.controller.ts
+++ b/src/controllers/scan.controller.ts
@@ -1,0 +1,671 @@
+import { Request, Response, NextFunction } from 'express';
+import scanService from '../services/scan.service';
+import scanLimitService from '../services/scan-limit.service';
+import Joi from 'joi';  
+
+// Extend Express Request interface untuk user data dari auth middleware
+declare global {
+  namespace Express {
+    interface Request {
+      user?: {
+        userId: string;
+        email: string;
+        role: string;
+      };
+    }
+  }
+}
+
+// Validation schemas
+const barcodeParamSchema = Joi.object({
+  barcode: Joi.string()
+    .pattern(/^[0-9]{8,14}$/)
+    .required()
+    .messages({
+      'string.pattern.base': 'Barcode must be 8-14 digits',
+      'any.required': 'Barcode is required'
+    })
+});
+
+const imageScanSchema = Joi.object({
+  imageUrl: Joi.string()
+    .uri()
+    .required()
+    .messages({
+      'string.uri': 'Must be a valid URL',
+      'any.required': 'Image URL is required'
+    }),
+  productId: Joi.number()
+    .integer()
+    .positive()
+    .optional()
+});
+
+const scanHistoryQuerySchema = Joi.object({
+  limit: Joi.number().integer().min(1).max(100).default(20),
+  offset: Joi.number().integer().min(0).default(0),
+  savedOnly: Joi.boolean().default(false)
+});
+
+export class ScanController {
+  /**
+   * POST /scans/barcode/:barcode
+   * Scan produk berdasarkan barcode
+   */
+  scanBarcode = async (req: Request, res: Response, next: NextFunction) => {
+    const startTime = Date.now();
+    const requestId = Math.random().toString(36).substring(7);
+    
+    console.log(`🔍 [${requestId}] [SCAN_BARCODE] Request started:`, {
+      method: req.method,
+      url: req.url,
+      path: req.path,
+      params: req.params,
+      query: req.query,
+      headers: {
+        'user-agent': req.headers['user-agent'],
+        'content-type': req.headers['content-type'],
+        'authorization': req.headers.authorization ? 'Bearer ***' : 'None'
+      },
+      timestamp: new Date().toISOString()
+    });
+
+    try {
+      // Bypass auth untuk development/testing
+      if (process.env.BYPASS_AUTH === 'true') {
+        console.log(`🔓 [${requestId}] [SCAN_BARCODE] Bypass auth enabled, using hardcoded user`);
+        // Set hardcoded user data
+        req.user = {
+          userId: process.env.HARDCODED_USER_ID || '1',
+          email: process.env.HARDCODED_USER_EMAIL || 'test@example.com',
+          role: process.env.HARDCODED_USER_ROLE || 'user'
+        };
+      }
+
+      // Validasi parameter
+      const { error: paramError, value: paramValue } = barcodeParamSchema.validate(req.params);
+      if (paramError) {
+        console.log(`❌ [${requestId}] [SCAN_BARCODE] Validation error:`, paramError.details);
+        return res.status(400).json({
+          success: false,
+          message: 'Validation error',
+          errors: paramError.details.map(detail => ({
+            field: detail.path.join('.'),
+            message: detail.message
+          }))
+        });
+      }
+
+      // Pastikan user sudah login
+      if (!req.user?.userId) {
+        console.log(`❌ [${requestId}] [SCAN_BARCODE] Authentication failed: No user data`);
+        return res.status(401).json({
+          success: false,
+          message: 'Authentication required'
+        });
+      }
+
+      const { barcode } = paramValue;
+      const userId = parseInt(req.user.userId);
+
+      console.log(`✅ [${requestId}] [SCAN_BARCODE] Validation passed:`, {
+        barcode,
+        userId,
+        userEmail: req.user.email,
+        userRole: req.user.role
+      });
+
+      // Proses scan barcode
+      console.log(`🔄 [${requestId}] [SCAN_BARCODE] Calling scanService.processBarcodeScan...`);
+      const scanResult = await scanService.processBarcodeScan(barcode, userId);
+      
+      console.log(`✅ [${requestId}] [SCAN_BARCODE] Service call successful:`, {
+        resultType: typeof scanResult,
+        hasData: !!scanResult,
+        timestamp: new Date().toISOString()
+      });
+
+      const responseTime = Date.now() - startTime;
+      console.log(`🎯 [${requestId}] [SCAN_BARCODE] Request completed successfully in ${responseTime}ms`);
+
+      res.status(200).json({
+        success: true,
+        message: 'Barcode scan completed successfully',
+        data: scanResult
+      });
+
+    } catch (error) {
+      const responseTime = Date.now() - startTime;
+      console.error(`💥 [${requestId}] [SCAN_BARCODE] Error occurred after ${responseTime}ms:`, {
+        error: error instanceof Error ? {
+          name: error.name,
+          message: error.message,
+          stack: error.stack
+        } : error,
+        requestInfo: {
+          method: req.method,
+          url: req.url,
+          params: req.params,
+          userId: req.user?.userId,
+          timestamp: new Date().toISOString()
+        }
+      });
+      next(error);
+    }
+  };
+
+  /**
+   * POST /scans/image
+   * Scan produk berdasarkan gambar (OCR fallback)
+   */
+  scanImage = async (req: Request, res: Response, next: NextFunction) => {
+    const startTime = Date.now();
+    const requestId = Math.random().toString(36).substring(7);
+    
+    console.log(`🖼️ [${requestId}] [SCAN_IMAGE] Request started:`, {
+      method: req.method,
+      url: req.url,
+      path: req.path,
+      body: req.body,
+      headers: {
+        'user-agent': req.headers['user-agent'],
+        'content-type': req.headers['content-type'],
+        'authorization': req.headers.authorization ? 'Bearer ***' : 'None'
+      },
+      timestamp: new Date().toISOString()
+    });
+
+    try {
+      // Bypass auth untuk development/testing
+      if (process.env.BYPASS_AUTH === 'true') {
+        console.log(`🔓 [${requestId}] [SCAN_IMAGE] Bypass auth enabled, using hardcoded user`);
+        // Set hardcoded user data
+        req.user = {
+          userId: process.env.HARDCODED_USER_ID || '1',
+          email: process.env.HARDCODED_USER_EMAIL || 'test@example.com',
+          role: process.env.HARDCODED_USER_ROLE || 'user'
+        };
+      }
+
+      // Validasi body request
+      const { error: bodyError, value: bodyValue } = imageScanSchema.validate(req.body);
+      if (bodyError) {
+        console.log(`❌ [${requestId}] [SCAN_IMAGE] Validation error:`, bodyError.details);
+        return res.status(400).json({
+          success: false,
+          message: 'Validation error',
+          errors: bodyError.details.map(detail => ({
+            field: detail.path.join('.'),
+            message: detail.message
+          }))
+        });
+      }
+
+      // Pastikan user sudah login
+      if (!req.user?.userId) {
+        console.log(`❌ [${requestId}] [SCAN_IMAGE] Authentication failed: No user data`);
+        return res.status(401).json({
+          success: false,
+          message: 'Authentication required'
+        });
+      }
+
+      const { imageUrl, productId } = bodyValue;
+      const userId = parseInt(req.user.userId);
+
+      console.log(`✅ [${requestId}] [SCAN_IMAGE] Validation passed:`, {
+        imageUrl,
+        productId,
+        userId,
+        userEmail: req.user.email,
+        userRole: req.user.role
+      });
+
+      // Proses scan gambar
+      console.log(`🔄 [${requestId}] [SCAN_IMAGE] Calling scanService.processImageScan...`);
+      const scanResult = await scanService.processImageScan(imageUrl, userId, productId);
+      
+      console.log(`✅ [${requestId}] [SCAN_IMAGE] Service call successful:`, {
+        resultType: typeof scanResult,
+        hasData: !!scanResult,
+        timestamp: new Date().toISOString()
+      });
+
+      const responseTime = Date.now() - startTime;
+      console.log(`🎯 [${requestId}] [SCAN_IMAGE] Request completed successfully in ${responseTime}ms`);
+
+      res.status(200).json({
+        success: true,
+        message: 'Image scan completed successfully',
+        data: scanResult
+      });
+
+    } catch (error) {
+      const responseTime = Date.now() - startTime;
+      console.error(`💥 [${requestId}] [SCAN_IMAGE] Error occurred after ${responseTime}ms:`, {
+        error: error instanceof Error ? {
+          name: error.name,
+          message: error.message,
+          stack: error.stack
+        } : error,
+        requestInfo: {
+          method: req.method,
+          url: req.url,
+          body: req.body,
+          userId: req.user?.userId,
+          timestamp: new Date().toISOString()
+        }
+      });
+      next(error);
+    }
+  };
+
+  /**
+   * PUT /scans/:scanId/save
+   * Toggle save status untuk hasil scan
+   */
+  toggleSaveScan = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      // Bypass auth untuk development/testing
+      if (process.env.BYPASS_AUTH === 'true') {
+        console.log(`🔓 [TOGGLE_SAVE] Bypass auth enabled, using hardcoded user`);
+        // Set hardcoded user data
+        req.user = {
+          userId: process.env.HARDCODED_USER_ID || '1',
+          email: process.env.HARDCODED_USER_EMAIL || 'test@example.com',
+          role: process.env.HARDCODED_USER_ROLE || 'user'
+        };
+      }
+
+      const scanIdParam = req.params.scanId;
+      
+      if (!scanIdParam) {
+        return res.status(400).json({
+          success: false,
+          message: 'Scan ID is required'
+        });
+      }
+      
+      const scanId = parseInt(scanIdParam);
+      
+      if (isNaN(scanId)) {
+        return res.status(400).json({
+          success: false,
+          message: 'Invalid scan ID'
+        });
+      }
+
+      // Pastikan user sudah login
+      if (!req.user?.userId) {
+        return res.status(401).json({
+          success: false,
+          message: 'Authentication required'
+        });
+      }
+
+      const userId = parseInt(req.user.userId);
+
+      // Toggle save status
+      const updatedScan = await scanService.toggleSaveScan(scanId, userId);
+
+      res.status(200).json({
+        success: true,
+        message: `Scan ${updatedScan.isSaved ? 'saved' : 'unsaved'} successfully`,
+        data: updatedScan
+      });
+
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  /**
+   * GET /scans/history
+   * Mendapatkan riwayat scan pengguna
+   */
+  getScanHistory = async (req: Request, res: Response, next: NextFunction) => {
+    const startTime = Date.now();
+    const requestId = Math.random().toString(36).substring(7);
+    
+    console.log(`📚 [${requestId}] [SCAN_HISTORY] Request started:`, {
+      method: req.method,
+      url: req.url,
+      path: req.path,
+      query: req.query,
+      headers: {
+        'user-agent': req.headers['user-agent'],
+        'content-type': req.headers['content-type'],
+        'authorization': req.headers.authorization ? 'Bearer ***' : 'None'
+      },
+      timestamp: new Date().toISOString()
+    });
+
+    try {
+      // Bypass auth untuk development/testing
+      if (process.env.BYPASS_AUTH === 'true') {
+        console.log(`🔓 [${requestId}] [SCAN_HISTORY] Bypass auth enabled, using hardcoded user`);
+        // Set hardcoded user data
+        req.user = {
+          userId: process.env.HARDCODED_USER_ID || '1',
+          email: process.env.HARDCODED_USER_EMAIL || 'test@example.com',
+          role: process.env.HARDCODED_USER_ROLE || 'user'
+        };
+      }
+
+      // Validasi query parameters
+      const { error: queryError, value: queryValue } = scanHistoryQuerySchema.validate(req.query);
+      if (queryError) {
+        console.log(`❌ [${requestId}] [SCAN_HISTORY] Validation error:`, queryError.details);
+        return res.status(400).json({
+          success: false,
+          message: 'Validation error',
+          errors: queryError.details.map(detail => ({
+            field: detail.path.join('.'),
+            message: detail.message
+          }))
+        });
+      }
+
+      // Pastikan user sudah login
+      if (!req.user?.userId) {
+        console.log(`❌ [${requestId}] [SCAN_HISTORY] Authentication failed: No user data`);
+        return res.status(401).json({
+          success: false,
+          message: 'Authentication required'
+        });
+      }
+
+      const userId = parseInt(req.user.userId);
+      const { limit, offset, savedOnly } = queryValue;
+
+      console.log(`✅ [${requestId}] [SCAN_HISTORY] Validation passed:`, {
+        userId,
+        limit,
+        offset,
+        savedOnly,
+        userEmail: req.user.email,
+        userRole: req.user.role
+      });
+
+      // Ambil riwayat scan
+      console.log(`🔄 [${requestId}] [SCAN_HISTORY] Calling scanService.getUserScanHistory...`);
+      const scanHistory = await scanService.getUserScanHistory(userId, {
+        limit,
+        offset,
+        savedOnly
+      });
+      
+      console.log(`✅ [${requestId}] [SCAN_HISTORY] Service call successful:`, {
+        resultCount: scanHistory.length,
+        timestamp: new Date().toISOString()
+      });
+
+      const responseTime = Date.now() - startTime;
+      console.log(`🎯 [${requestId}] [SCAN_HISTORY] Request completed successfully in ${responseTime}ms`);
+
+      res.status(200).json({
+        success: true,
+        message: 'Scan history retrieved successfully',
+        data: {
+          scans: scanHistory,
+          pagination: {
+            limit,
+            offset,
+            total: scanHistory.length
+          }
+        }
+      });
+
+    } catch (error) {
+      const responseTime = Date.now() - startTime;
+      console.error(`💥 [${requestId}] [SCAN_HISTORY] Error occurred after ${responseTime}ms:`, {
+        error: error instanceof Error ? {
+          name: error.name,
+          message: error.message,
+          stack: error.stack
+        } : error,
+        requestInfo: {
+          method: req.method,
+          url: req.url,
+          query: req.query,
+          userId: req.user?.userId,
+          timestamp: new Date().toISOString()
+        }
+      });
+      next(error);
+    }
+  };
+
+  /**
+   * GET /scans/saved
+   * Shortcut untuk mendapatkan scan yang disimpan
+   */
+  getSavedScans = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      // Set savedOnly = true dan forward ke getScanHistory
+      req.query.savedOnly = 'true';
+      return await this.getScanHistory(req, res, next);
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  /**
+   * POST /scans/upload
+   * Upload dan scan gambar produk untuk analisis alergi
+   */
+  uploadAndScanImage = async (req: Request, res: Response, next: NextFunction) => {
+    const startTime = Date.now();
+    const requestId = Math.random().toString(36).substring(7);
+    
+    console.log(`📸 [${requestId}] [UPLOAD_SCAN] Request started:`, {
+      method: req.method,
+      url: req.url,
+      path: req.path,
+      headers: {
+        'user-agent': req.headers['user-agent'],
+        'content-type': req.headers['content-type'],
+        'authorization': req.headers.authorization ? 'Bearer ***' : 'None'
+      },
+      timestamp: new Date().toISOString()
+    });
+
+    try {
+      // Bypass auth untuk development/testing
+      if (process.env.BYPASS_AUTH === 'true') {
+        console.log(`🔓 [${requestId}] [UPLOAD_SCAN] Bypass auth enabled, using hardcoded user`);
+        // Set hardcoded user data
+        req.user = {
+          userId: process.env.HARDCODED_USER_ID || '1',
+          email: process.env.HARDCODED_USER_EMAIL || 'test@example.com',
+          role: process.env.HARDCODED_USER_ROLE || 'user'
+        };
+      }
+
+      // Pastikan user sudah login
+      if (!req.user?.userId) {
+        console.log(`❌ [${requestId}] [UPLOAD_SCAN] Authentication failed: No user data`);
+        return res.status(401).json({
+          success: false,
+          message: 'Authentication required'
+        });
+      }
+
+      // Validasi file upload
+      if (!req.file) {
+        console.log(`❌ [${requestId}] [UPLOAD_SCAN] No image file uploaded`);
+        return res.status(400).json({
+          success: false,
+          message: 'Image file is required'
+        });
+      }
+
+      // Validasi file type
+      if (!req.file.mimetype.startsWith('image/')) {
+        console.log(`❌ [${requestId}] [UPLOAD_SCAN] Invalid file type: ${req.file.mimetype}`);
+        return res.status(400).json({
+          success: false,
+          message: 'Only image files are allowed'
+        });
+      }
+
+      const userId = parseInt(req.user.userId);
+      const productName = req.body.productName || undefined;
+
+      console.log(`✅ [${requestId}] [UPLOAD_SCAN] Validation passed:`, {
+        userId,
+        userEmail: req.user.email,
+        userRole: req.user.role,
+        fileName: req.file.originalname,
+        fileSize: req.file.size,
+        fileType: req.file.mimetype,
+        productName
+      });
+
+      // Proses upload dan scan
+      console.log(`🔄 [${requestId}] [UPLOAD_SCAN] Calling scanService.processImageUpload...`);
+      const scanResult = await scanService.processImageUpload(
+        req.file.buffer,
+        userId,
+        productName
+      );
+      
+      console.log(`✅ [${requestId}] [UPLOAD_SCAN] Service call successful:`, {
+        scanResult: {
+          id: scanResult.id,
+          productId: scanResult.productId,
+          riskLevel: scanResult.riskLevel,
+          matchedAllergens: scanResult.matchedAllergens
+        },
+        timestamp: new Date().toISOString()
+      });
+
+      const responseTime = Date.now() - startTime;
+      console.log(`🎯 [${requestId}] [UPLOAD_SCAN] Request completed successfully in ${responseTime}ms`);
+
+      res.status(200).json({
+        success: true,
+        message: 'Image uploaded and analyzed successfully',
+        data: scanResult
+      });
+
+    } catch (error) {
+      const responseTime = Date.now() - startTime;
+      console.error(`💥 [${requestId}] [UPLOAD_SCAN] Error occurred after ${responseTime}ms:`, {
+        error: error instanceof Error ? {
+          name: error.name,
+          message: error.message,
+          stack: error.stack
+        } : error,
+        requestInfo: {
+          method: req.method,
+          url: req.url,
+          userId: req.user?.userId,
+          fileName: req.file?.originalname,
+          timestamp: new Date().toISOString()
+        }
+      });
+      next(error);
+    }
+  };
+
+  /**
+   * GET /scans/limit
+   * Mendapatkan informasi daily scan limit pengguna
+   */
+  getUserScanLimit = async (req: Request, res: Response, next: NextFunction) => {
+    const startTime = Date.now();
+    const requestId = Math.random().toString(36).substring(7);
+    
+    console.log(`📊 [${requestId}] [SCAN_LIMIT] Request started:`, {
+      method: req.method,
+      url: req.url,
+      path: req.path,
+      headers: {
+        'user-agent': req.headers['user-agent'],
+        'content-type': req.headers['content-type'],
+        'authorization': req.headers.authorization ? 'Bearer ***' : 'None'
+      },
+      timestamp: new Date().toISOString()
+    });
+
+    try {
+      // Bypass auth untuk development/testing
+      if (process.env.BYPASS_AUTH === 'true') {
+        console.log(`🔓 [${requestId}] [SCAN_LIMIT] Bypass auth enabled, using hardcoded user`);
+        // Set hardcoded user data
+        req.user = {
+          userId: process.env.HARDCODED_USER_ID || '1',
+          email: process.env.HARDCODED_USER_EMAIL || 'test@example.com',
+          role: process.env.HARDCODED_USER_ROLE || 'user'
+        };
+      }
+
+      // Pastikan user sudah login
+      if (!req.user?.userId) {
+        console.log(`❌ [${requestId}] [SCAN_LIMIT] Authentication failed: No user data`);
+        return res.status(401).json({
+          success: false,
+          message: 'Authentication required'
+        });
+      }
+
+      const userId = parseInt(req.user.userId);
+
+      console.log(`✅ [${requestId}] [SCAN_LIMIT] Validation passed:`, {
+        userId,
+        userEmail: req.user.email,
+        userRole: req.user.role
+      });
+
+      // Ambil informasi scan limit
+      console.log(`🔄 [${requestId}] [SCAN_LIMIT] Calling scanLimitService.getUserDailyScanLimit...`);
+      const limitInfo = await scanLimitService.getUserDailyScanLimit(userId);
+      
+      console.log(`✅ [${requestId}] [SCAN_LIMIT] Service call successful:`, {
+        limitInfo: {
+          userId: limitInfo.userId,
+          currentUsage: limitInfo.currentUsage,
+          dailyLimit: limitInfo.dailyLimit,
+          remainingScans: limitInfo.remainingScans
+        },
+        timestamp: new Date().toISOString()
+      });
+
+      const responseTime = Date.now() - startTime;
+      console.log(`🎯 [${requestId}] [SCAN_LIMIT] Request completed successfully in ${responseTime}ms`);
+
+      res.status(200).json({
+        success: true,
+        message: 'Scan limit information retrieved successfully',
+        data: {
+          userId: limitInfo.userId,
+          currentUsage: limitInfo.currentUsage,
+          dailyLimit: limitInfo.dailyLimit,
+          remainingScans: limitInfo.remainingScans,
+          isLimitExceeded: limitInfo.isLimitExceeded,
+          canScan: !limitInfo.isLimitExceeded
+        }
+      });
+
+    } catch (error) {
+      const responseTime = Date.now() - startTime;
+      console.error(`💥 [${requestId}] [SCAN_LIMIT] Error occurred after ${responseTime}ms:`, {
+        error: error instanceof Error ? {
+          name: error.name,
+          message: error.message,
+          stack: error.stack
+        } : error,
+        requestInfo: {
+          method: req.method,
+          url: req.url,
+          userId: req.user?.userId,
+          timestamp: new Date().toISOString()
+        }
+      });
+      next(error);
+    }
+  };
+}
+
+export default new ScanController();

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import helmet from 'helmet';
 import rateLimit  from 'express-rate-limit';
 import dotenv from 'dotenv';
 import { Prisma, PrismaClient } from '@prisma/client';
+import authRoutes from "./routes/auth.routes"
 
 
 
@@ -45,6 +46,8 @@ app.get('/health', (req, res) => {
   });
 });
 
+// API versioning
+app.use("/api/v1/auth", authRoutes);
 
 
 app.listen(port, () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import rateLimit  from 'express-rate-limit';
 import dotenv from 'dotenv';
 import { Prisma, PrismaClient } from '@prisma/client';
 import authRoutes from "./routes/auth.routes"
+import { errorHandler } from './middlewares/error.middleware';
 
 
 
@@ -48,6 +49,9 @@ app.get('/health', (req, res) => {
 
 // API versioning
 app.use("/api/v1/auth", authRoutes);
+
+//error handler
+app.use(errorHandler);
 
 
 app.listen(port, () => {

--- a/src/middlewares/asyncHandler.ts
+++ b/src/middlewares/asyncHandler.ts
@@ -1,0 +1,12 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+/**
+ * Async handler wrapper untuk menangkap error dalam fungsi async
+ * dan meneruskannya ke middleware error handling Express
+ */
+const asyncHandler = (fn: RequestHandler) => 
+  (req: Request, res: Response, next: NextFunction) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+
+export default asyncHandler;

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -1,0 +1,135 @@
+import { string } from "joi";
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import nodemailer from "nodemailer";
+export async function sendOTPEmail(to: string, otp: string){
+    let transporter = nodemailer.createTransport({
+        service: "gmail",
+        secure: true,
+        auth: {
+            user: process.env.SMTP_USER,
+            pass: process.env.SMTP_PASS,
+        },
+    });
+
+    let info = await transporter.sendMail({
+        from: process.env.SMTP_FROM, //sender
+        to: to, //reciever
+        subject: "OTP Verification Code",
+        text: `Hi there,
+Your verification code for Allertify is:${otp}
+This code is valid for 5 minutes. 
+Please do not share this code with anyone to keep your account secure.
+Thanks,
+The Allertify Team`,
+    });
+    console.log("Code has been sent: %s", info.response);
+}
+
+
+// Interface untuk JWT payload
+interface JwtPayload {
+    userId: string;
+    email: string;
+    role: string;
+  }
+  
+  // Extend Express Request interface
+  declare global {
+    namespace Express {
+      interface Request {
+        user?: JwtPayload;
+      }
+    }
+  }
+  
+  /**
+   * Middleware untuk autentikasi JWT
+   * TODO: implementasi sementara
+   */
+  export const authenticateToken = (req: Request, res: Response, next: NextFunction) => {
+    try {
+      // Bypass authentication jika environment variable BYPASS_AUTH = true
+      if (process.env.BYPASS_AUTH === 'true') {
+       
+        req.user = {
+          userId: process.env.HARDCODED_USER_ID || '1',
+          email: process.env.HARDCODED_USER_EMAIL || 'test@example.com',
+          role: process.env.HARDCODED_USER_ROLE || 'user'
+        };
+        console.log('🔓 AUTH BYPASSED - Using hardcoded user:', req.user);
+        return next();
+      }
+  
+      const authHeader = req.headers.authorization;
+      const token = authHeader && authHeader.split(' ')[1];
+  
+      if (!token) {
+        return res.status(401).json({
+          success: false,
+          message: 'Access token is required',
+        });
+      }
+  
+      // Verifikasi JWT token
+      const JWT_SECRET = process.env.JWT_ACCESS_SECRET || 'your-secret-key';
+      const decoded = jwt.verify(token, JWT_SECRET) as JwtPayload;
+      
+      req.user = decoded;
+      next();
+  
+    } catch (error) {
+      console.error('Token verification error:', error);
+      
+      if (error instanceof jwt.TokenExpiredError) {
+        return res.status(401).json({
+          success: false,
+          message: 'Access token has expired',
+          code: 'TOKEN_EXPIRED',
+        });
+      }
+      
+      if (error instanceof jwt.JsonWebTokenError) {
+        return res.status(401).json({
+          success: false,
+          message: 'Invalid access token',
+          code: 'INVALID_TOKEN',
+        });
+      }
+  
+      return res.status(401).json({
+        success: false,
+        message: 'Authentication failed',
+      });
+    }
+  };
+  
+  /**
+   * Middleware untuk otorisasi berdasarkan role
+   */
+  export const requireRole = (roles: string[]) => {
+    return (req: Request, res: Response, next: NextFunction) => {
+      if (!req.user) {
+        return res.status(401).json({
+          success: false,
+          message: 'Authentication required',
+        });
+      }
+  
+      if (!roles.includes(req.user.role)) {
+        return res.status(403).json({
+          success: false,
+          message: 'Insufficient permissions',
+        });
+      }
+  
+      next();
+    };
+  };
+  
+  
+  
+  
+  
+  
+  

--- a/src/middlewares/auth.validation.ts
+++ b/src/middlewares/auth.validation.ts
@@ -17,3 +17,8 @@ export const otpSchema = Joi.object({
     email: Joi.string().trim().lowercase().email().max(100).required(),
     otp: Joi.string().length(6).pattern(/^\d{6}$/).required(),
 })
+
+export const loginSchema = Joi.object({
+    email: Joi.string().trim().lowercase().email().max(100).required(),
+    password: Joi.string().min(8).max(255).required(),
+});

--- a/src/middlewares/auth.validation.ts
+++ b/src/middlewares/auth.validation.ts
@@ -1,0 +1,19 @@
+import Joi, { required } from "joi";
+
+export const registerSchema = Joi.object({
+    full_name: Joi.string().trim().min(3).max(100).required(),
+    email: Joi.string().trim().lowercase().email().max(100).required(),
+    password: Joi.string()
+        .min(8)
+        .max(255)
+        .pattern(/[a-z]/) //lowcase
+        .pattern(/[A-Z]/) //upcase
+        .pattern(/[0-9]/) //number
+        .required(),
+    phone_number: Joi.string().trim().pattern(/[0-9+\-]{8,20}$/).required()
+})
+
+export const otpSchema = Joi.object({
+    email: Joi.string().trim().lowercase().email().max(100).required(),
+    otp: Joi.string().length(6).pattern(/^\d{6}$/).required(),
+})

--- a/src/middlewares/error.middleware.ts
+++ b/src/middlewares/error.middleware.ts
@@ -1,0 +1,45 @@
+import { Request, Response, NextFunction } from 'express';
+import { logger } from '../utils/logger';
+
+export interface AppError extends Error {
+  statusCode?: number;
+  isOperational?: boolean;
+}
+
+export const errorHandler = (
+  error: AppError,
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const statusCode = error.statusCode || 500;
+  const message = error.message || 'Internal Server Error';
+
+  // Log error
+  logger.error('Error occurred:', {
+    message: error.message,
+    stack: error.stack,
+    url: req.originalUrl,
+    method: req.method,
+    ip: req.ip,
+    userAgent: req.get('User-Agent'),
+  });
+
+ 
+  const responseMessage = process.env.NODE_ENV === 'production' && statusCode === 500
+    ? 'Something went wrong!'
+    : message;
+
+  res.status(statusCode).json({
+    success: false,
+    message: responseMessage,
+    ...(process.env.NODE_ENV === 'development' && { stack: error.stack }),
+  });
+};
+
+export const createError = (statusCode: number, message: string): AppError => {
+  const error: AppError = new Error(message);
+  error.statusCode = statusCode;
+  error.isOperational = true;
+  return error;
+};

--- a/src/middlewares/google.gen.ai.ts
+++ b/src/middlewares/google.gen.ai.ts
@@ -1,0 +1,6 @@
+
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+
+export const google = createGoogleGenerativeAI({
+    apiKey: process.env.GEMINI_API_KEY || '',
+});

--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import { registerController, verifyOtpController } from "../controllers/auth.controller";
+
+const router = Router();
+
+// endpoint register
+router.post("/register", registerController);
+// endpoint otp
+router.post("/otp", verifyOtpController);
+
+export default router;

--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { registerController, verifyOtpController } from "../controllers/auth.controller";
+import { registerController, verifyOtpController, loginController } from "../controllers/auth.controller";
 
 const router = Router();
 
@@ -7,5 +7,7 @@ const router = Router();
 router.post("/register", registerController);
 // endpoint otp
 router.post("/otp", verifyOtpController);
+// endpoint login
+router.post("/login", loginController);
 
 export default router;

--- a/src/routes/scan.routes.ts
+++ b/src/routes/scan.routes.ts
@@ -1,0 +1,88 @@
+import { Router } from 'express';
+import scanController from '../controllers/scan.controller';
+import { authenticateToken } from '../middlewares/auth.middleware';
+import asyncHandler from '../middlewares/asyncHandler';
+import multer from 'multer';
+
+const router = Router();
+
+// Configure multer for image uploads
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: 10 * 1024 * 1024, // 10MB limit
+  },
+  fileFilter: (req, file, cb) => {
+    // Only allow image files
+    if (file.mimetype.startsWith('image/')) {
+      cb(null, true);
+    } else {
+      cb(new Error('Only image files are allowed'));
+    }
+  },
+});
+
+router.use(authenticateToken);  
+
+/**
+ * GET /scans/limit
+ * Mendapatkan informasi daily scan limit pengguna
+ */
+router.get('/limit', asyncHandler(scanController.getUserScanLimit));
+
+/**
+ * POST /scans/barcode/:barcode
+ * Scan produk berdasarkan barcode
+ */
+router.post('/barcode/:barcode', asyncHandler(scanController.scanBarcode));
+
+/**
+ * POST /scans/image
+ * Scan produk berdasarkan gambar (OCR fallback)
+ * Body: { imageUrl: string, productId?: number }
+ */
+router.post('/image', asyncHandler(scanController.scanImage));
+
+/**
+ * POST /scans/upload
+ * Upload dan scan gambar produk untuk analisis alergi
+ * Body: multipart/form-data dengan field 'image' dan optional 'productName'
+ */
+router.post('/upload', upload.single('image'), asyncHandler(scanController.uploadAndScanImage));
+
+/**
+ * POST /scans/upload-simple
+ * Test route tanpa multer untuk debugging
+ */
+router.post('/upload-simple', asyncHandler(scanController.uploadAndScanImage));
+
+/**
+ * GET /scans/upload-test
+ * Test route untuk memastikan /upload terdaftar
+ */
+router.get('/upload-test', (req, res) => {
+  res.json({ message: 'Upload route is working!', timestamp: new Date().toISOString() });
+});
+
+/**
+ * PUT /scans/:scanId/save
+ * Toggle save status untuk hasil scan
+ */
+router.put('/save/:scanId', asyncHandler(scanController.toggleSaveScan));
+
+/**
+ * GET /scans/history
+ * Mendapatkan riwayat scan pengguna
+ * Query params: limit?, offset?, savedOnly?
+ */
+router.get('/history', asyncHandler(scanController.getScanHistory));
+
+/**
+ * GET /scans/saved
+ * Shortcut untuk mendapatkan scan yang disimpan
+ */
+router.get('/saved', asyncHandler(scanController.getSavedScans));
+
+export default router;
+
+

--- a/src/services/ai.service.ts
+++ b/src/services/ai.service.ts
@@ -1,0 +1,410 @@
+import { generateObject } from 'ai';
+import { z } from 'zod';
+import { google } from '../middlewares/google.gen.ai';
+
+
+export const AIEvaluationSchema = z.object({
+  riskLevel: z.enum(['SAFE', 'CAUTION', 'RISKY']),
+  matchedAllergens: z.array(z.string()),
+  reasoning: z.string(),
+});
+
+export type AIEvaluation = z.infer<typeof AIEvaluationSchema>;
+
+export class AIService {
+  private geminiModel = google('gemini-2.5-flash');
+  private geminiVisionModel = google('gemini-2.5-flash');
+
+  /**
+   * Mock AI response untuk development/testing 
+   */
+  private getMockAIResponse(userAllergies: string[], ingredientsText: string): AIEvaluation {
+    console.log('🤖 AI BYPASSED - Using mock response');
+    
+    // Simple logic untuk mock response
+    const lowerIngredients = ingredientsText.toLowerCase();
+    const matchedAllergens: string[] = [];
+    
+    // Check untuk common allergens
+    userAllergies.forEach(allergen => {
+      const allergenLower = allergen.toLowerCase();
+      if (lowerIngredients.includes(allergenLower) || 
+          lowerIngredients.includes(allergenLower.replace(' ', ''))) {
+        matchedAllergens.push(allergen);
+      }
+    });
+    
+    let riskLevel: 'SAFE' | 'CAUTION' | 'RISKY' = 'SAFE';
+    let reasoning = 'Product appears safe based on ingredient analysis.';
+    
+    if (matchedAllergens.length > 0) {
+      riskLevel = 'RISKY';
+      reasoning = `⚠️ HIGH RISK: Detected allergens: ${matchedAllergens.join(', ')}. Avoid this product.`;
+    } else if (lowerIngredients.includes('may contain') || lowerIngredients.includes('traces of')) {
+      riskLevel = 'CAUTION';
+      reasoning = '⚠️ CAUTION: Product may contain traces of allergens. Check with manufacturer.';
+    } else if (lowerIngredients.includes('natural flavors') || lowerIngredients.includes('spices')) {
+      riskLevel = 'CAUTION';
+      reasoning = '⚠️ CAUTION: Contains natural flavors/spices that may include allergens.';
+    }
+    
+    return {
+      riskLevel,
+      matchedAllergens,
+      reasoning
+    };
+  }
+
+  /**
+   * Menganalisis teks bahan/ingredients berdasarkan alergi pengguna
+   */
+  async analyzeIngredientsText(
+    ingredientsText: string, 
+    userAllergies: string[]
+  ): Promise<AIEvaluation> {
+    try {
+      if (!ingredientsText || ingredientsText.trim() === '') {
+        throw new Error('Ingredients text cannot be empty');
+      }
+
+      if (!userAllergies || userAllergies.length === 0) {
+        // Jika user tidak punya alergi, kembalikan hasil SAFE
+        return {
+          riskLevel: 'SAFE',
+          matchedAllergens: [],
+          reasoning: 'No allergies specified by user, product is considered safe.'
+        };
+      }
+
+      // Bypass AI jika environment variable BYPASS_AI = true
+      if (process.env.BYPASS_AI === 'true' || process.env.BYPASS_AUTH === 'true') {
+        return this.getMockAIResponse(userAllergies, ingredientsText);
+      }
+
+      const prompt = `
+You are an expert nutritionist and allergy specialist. Your task is to analyze food ingredients and assess allergy risks.
+
+USER ALLERGIES: ${userAllergies.join(', ')}
+
+INGREDIENTS TO ANALYZE: "${ingredientsText}"
+
+Please analyze the ingredients text above and determine:
+1. Risk level based on the presence of user's allergens
+2. Which specific allergens from the user's list are found in the ingredients
+3. Detailed reasoning for your assessment
+
+RISK LEVELS:
+- SAFE: No allergens detected, safe for consumption
+- CAUTION: Possible cross-contamination or unclear ingredients that might contain allergens
+- RISKY: Direct presence of user's allergens, should avoid
+
+Consider:
+- Direct ingredient matches (e.g., "milk" matches "dairy/milk" allergy)
+- Alternative names (e.g., "casein" for milk, "albumin" for eggs)
+- Cross-contamination warnings (e.g., "may contain traces of...")
+- Processing aids and additives that might contain allergens
+
+Provide a thorough but concise reasoning that explains your decision.
+      `;
+
+      const result = await generateObject({
+        model: this.geminiModel,
+        schema: AIEvaluationSchema,
+        prompt,
+        temperature: 0.1, 
+      });
+
+      return result.object;
+
+    } catch (error) {
+      console.error('Error in analyzeIngredientsText:', error);
+      
+      // Fallback ke mock response jika AI gagal
+      if (process.env.BYPASS_AI === 'true' || process.env.BYPASS_AUTH === 'true') {
+        console.log('🔄 AI failed, falling back to mock response');
+        return this.getMockAIResponse(userAllergies, ingredientsText);
+      }
+      
+      if (error instanceof Error) {
+        throw new Error(`AI analysis failed: ${error.message}`);
+      }
+      
+      throw new Error('Unknown error occurred during AI analysis');
+    }
+  }
+
+  /**
+   * Menganalisis gambar produk untuk ekstraksi OCR dan analisis alergi
+   */
+  async analyzeProductImage(
+    imageUrl: string, 
+    userAllergies: string[]
+  ): Promise<AIEvaluation> {
+    try {
+      if (!imageUrl || imageUrl.trim() === '') {
+        throw new Error('Image URL cannot be empty');
+      }
+
+      if (!userAllergies || userAllergies.length === 0) {
+        // Jika user tidak punya alergi, kembalikan hasil SAFE
+        return {
+          riskLevel: 'SAFE',
+          matchedAllergens: [],
+          reasoning: 'No allergies specified by user, product is considered safe.'
+        };
+      }
+
+      // Bypass AI jika environment variable BYPASS_AI = true
+      if (process.env.BYPASS_AI === 'true') {
+        return {
+          riskLevel: 'CAUTION',
+          matchedAllergens: [],
+          reasoning: '🤖 AI BYPASSED - Image analysis requires AI service. Set BYPASS_AI=false to enable real AI analysis.'
+        };
+      }
+
+      const prompt = `
+You are an expert nutritionist and allergy specialist. Your task is to analyze food product images and assess allergy risks.
+
+USER ALLERGIES: ${userAllergies.join(', ')}
+
+Please analyze the product image above and determine:
+1. Risk level based on the presence of user's allergens
+2. Which specific allergens from the user's list are found in the product
+3. Detailed reasoning for your assessment
+
+Look for:
+- Ingredient lists on packaging
+- Allergy warnings (e.g., "Contains: milk, nuts")
+- Cross-contamination notices
+- Product name and brand information
+
+RISK LEVELS:
+- SAFE: No allergens detected, safe for consumption
+- CAUTION: Possible cross-contamination or unclear information that might contain allergens
+- RISKY: Direct presence of user's allergens, should avoid
+
+Provide a thorough but concise reasoning that explains your decision.
+      `;
+
+      const result = await generateObject({
+        model: this.geminiVisionModel,
+        schema: AIEvaluationSchema,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: prompt
+              },
+              {
+                type: 'image',
+                image: imageUrl
+              }
+            ]
+          }
+        ],
+        temperature: 0.1,
+      });
+
+      return result.object;
+
+    } catch (error) {
+      console.error('Error in analyzeProductImage:', error);
+      
+      // Fallback ke mock response jika AI gagal
+      if (process.env.BYPASS_AI === 'true' ) {
+        console.log('🔄 AI failed, falling back to mock response');
+        return {
+          riskLevel: 'CAUTION',
+          matchedAllergens: [],
+          reasoning: '🤖 AI BYPASSED - Image analysis failed. Set BYPASS_AI=false to enable real AI analysis.'
+        };
+      }
+      
+      if (error instanceof Error) {
+        throw new Error(`AI image analysis failed: ${error.message}`);
+      }
+      
+      throw new Error('Unknown error occurred during AI image analysis');
+    }
+  }
+
+  /**
+   * Menganalisis gambar produk yang diupload ke Cloudinary
+   */
+  async analyzeUploadedImage(
+    cloudinaryUrl: string,
+    userAllergies: string[]
+  ): Promise<AIEvaluation> {
+    try {
+      if (!cloudinaryUrl || cloudinaryUrl.trim() === '') {
+        throw new Error('Cloudinary URL cannot be empty');
+      }
+
+      if (!userAllergies || userAllergies.length === 0) {
+        // Jika user tidak punya alergi, kembalikan hasil SAFE
+        return {
+          riskLevel: 'SAFE',
+          matchedAllergens: [],
+          reasoning: 'No allergies specified by user, product is considered safe.'
+        };
+      }
+
+      // Bypass AI jika environment variable BYPASS_AI = true
+      if (process.env.BYPASS_AI === 'true' ) {
+        return {
+          riskLevel: 'CAUTION',
+          matchedAllergens: [],
+          reasoning: '🤖 AI BYPASSED - Image analysis requires AI service. Set BYPASS_AI=false to enable real AI analysis.'
+        };
+      }
+
+      const prompt = `
+You are an expert nutritionist and allergy specialist. Your task is to analyze food product images and assess allergy risks.
+
+USER ALLERGIES: ${userAllergies.join(', ')}
+
+Please analyze the product image above and determine:
+1. Risk level based on the presence of user's allergens
+2. Which specific allergens from the user's list are found in the product
+3. Detailed reasoning for your assessment
+
+Look for:
+- Ingredient lists on packaging
+- Allergy warnings (e.g., "Contains: milk, nuts")
+- Cross-contamination notices
+- Product name and brand information
+- Nutritional information panels
+- Any text visible on the packaging
+
+RISK LEVELS:
+- SAFE: No allergens detected, safe for consumption
+- CAUTION: Possible cross-contamination or unclear information that might contain allergens
+- RISKY: Direct presence of user's allergens, should avoid
+
+Provide a thorough but concise reasoning that explains your decision.
+      `;
+
+      const result = await generateObject({
+        model: this.geminiVisionModel,
+        schema: AIEvaluationSchema,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: prompt
+              },
+              {
+                type: 'image',
+                image: cloudinaryUrl
+              }
+            ]
+          }
+        ],
+        temperature: 0.1,
+      });
+
+      return result.object;
+
+    } catch (error) {
+      console.error('Error in analyzeUploadedImage:', error);
+      
+      // Fallback ke mock response jika AI gagal
+      if (process.env.BYPASS_AI === 'true') {
+        console.log('🔄 AI failed, falling back to mock response');
+        return {
+          riskLevel: 'CAUTION',
+          matchedAllergens: [],
+          reasoning: '🤖 AI BYPASSED - Image analysis failed. Set BYPASS_AI=false to enable real AI analysis.'
+        };
+      }
+      
+      if (error instanceof Error) {
+        throw new Error(`AI uploaded image analysis failed: ${error.message}`);
+      }
+      
+      throw new Error('Unknown error occurred during AI uploaded image analysis');
+    }
+  }
+
+  /**
+   * Menganalisis teks bahan dengan konteks tambahan (brand, product name, dll)
+   */
+  async analyzeIngredientsWithContext(
+    ingredientsText: string,
+    userAllergies: string[],
+    context: {
+      productName?: string;
+      brand?: string;
+      category?: string;
+    }
+  ): Promise<AIEvaluation> {
+    try {
+      // Bypass AI jika environment variable BYPASS_AI = true
+      if (process.env.BYPASS_AI === 'true' || process.env.BYPASS_AUTH === 'true') {
+        return this.getMockAIResponse(userAllergies, ingredientsText);
+      }
+
+      const contextInfo = [];
+      if (context.productName) contextInfo.push(`Product: ${context.productName}`);
+      if (context.brand) contextInfo.push(`Brand: ${context.brand}`);
+      if (context.category) contextInfo.push(`Category: ${context.category}`);
+      
+      const contextString = contextInfo.length > 0 ? `\n\nADDITIONAL CONTEXT:\n${contextInfo.join('\n')}` : '';
+
+      const prompt = `
+You are an expert nutritionist and allergy specialist. Your task is to analyze food ingredients and assess allergy risks.
+
+USER ALLERGIES: ${userAllergies.join(', ')}
+
+INGREDIENTS TO ANALYZE: "${ingredientsText}"${contextString}
+
+Please analyze the ingredients text above and determine:
+1. Risk level based on the presence of user's allergens
+2. Which specific allergens from the user's list are found in the ingredients
+3. Detailed reasoning for your assessment
+
+Use the additional context to better understand the product type and potential hidden allergens.
+
+RISK LEVELS:
+- SAFE: No allergens detected, safe for consumption
+- CAUTION: Possible cross-contamination or unclear ingredients that might contain allergens
+- RISKY: Direct presence of user's allergens, should avoid
+
+Provide a thorough but concise reasoning that explains your decision.
+      `;
+
+      const result = await generateObject({
+        model: this.geminiModel,
+        schema: AIEvaluationSchema,
+        prompt,
+        temperature: 0.1,
+      });
+
+      return result.object;
+
+    } catch (error) {
+      console.error('Error in analyzeIngredientsWithContext:', error);
+      
+      // Fallback ke mock response jika AI gagal
+      if (process.env.BYPASS_AI === 'true' || process.env.BYPASS_AUTH === 'true') {
+        console.log('🔄 AI failed, falling back to mock response');
+        return this.getMockAIResponse(userAllergies, ingredientsText);
+      }
+      
+      if (error instanceof Error) {
+        throw new Error(`AI contextual analysis failed: ${error.message}`);
+      }
+      
+      throw new Error('Unknown error occurred during AI contextual analysis');
+    }
+  }
+}
+
+export default new AIService();
+
+

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,0 +1,140 @@
+import { PrismaClient } from "@prisma/client";
+import argon2 from "argon2"
+import { date } from "joi";
+import jwt from "jsonwebtoken"
+import { sendOTPEmail } from "../utils/mailer";
+
+const prisma = new PrismaClient();
+
+function generateOTP(): string {
+    const num = Math.floor(Math.random()*1_000_000); //0-999999
+    return num.toString().padStart(6,"0"); 
+}
+
+export async function createUser(input: {
+   full_name: string;
+   email: string;
+   password: string;
+   phone_number: string;
+}) {
+    const email = input.email.toLowerCase().trim();
+    const existing = await prisma.user.findUnique({ where: { email } });
+    if(existing && existing.is_verified) {
+        return { status: "ALREADY_VERIFIED" as const};
+    }
+    let userId: number;
+    if(!existing) {
+        const hashed = await argon2.hash(input.password, { type: argon2.argon2id });
+        const created = await prisma.user.create({
+            data: {
+                full_name: input.full_name, 
+                email,
+                password: hashed,
+                phone_number: input.phone_number,
+                is_verified: false,
+                role: 0, // default
+                profile_picture_url: null,
+            },
+            select: { id: true },
+        });
+        userId = created.id;
+    } else {
+        userId = existing.id;
+    }
+
+    //clean up otp when it's unused
+    await prisma.email_verification.deleteMany({
+        where: { user_id: userId, usedAt: null}
+    });
+
+    //generate otp and expired in 5 min
+    const otp = generateOTP();
+    const otpExpired = new Date(Date.now() + 5 * 60 *1000);
+
+    await prisma.email_verification.create({
+        data: {
+            user_id: userId,
+            otp_code: otp,
+            otp_code_expired: otpExpired,
+        },
+    });
+
+    //send otp to email
+    await sendOTPEmail(email, otp);
+
+    console.log(`[OTP] send to ${email}: ${otp} (valid until ${otpExpired.toISOString()})`);
+
+    return { status: existing? "OTP_RESENT" as const : "REGISTERED" as const};
+
+}
+
+// verif otp for an email and issue an access token
+export async function verifyOtpAndIssueToken(input: {
+    email: string;
+    otp: string;
+}) {
+    const email = input.email.toLowerCase().trim();
+    const user = await prisma.user.findUnique({ where: { email } });
+    if(!user){
+        return { ok: false as const, reason: "USER_NOT_FOUND" as const };        
+    }
+
+    const record = await prisma.email_verification.findFirst({
+        where: { user_id: user.id, usedAt: null },
+        orderBy: { createdAt: "desc"},
+    });
+
+    if(!record){
+        return { ok: false as const, reason: "OTP_NOT_FOUND_OR_EXPIRED" as const };
+    }
+
+    //check expired
+    if(record.otp_code_expired < new Date()){
+        //mark used or exp
+        await prisma.email_verification.update({
+            where: { id: record.id },
+            data: { usedAt: new Date() },
+        });
+        return { ok: false as const, reason: "OTP_EXPIRED" as const }
+    }
+    if(record.otp_code !== input.otp){
+        return { ok: false as const, reason: "OTP_INVALID"}
+    }
+
+    // mark used
+    await prisma.email_verification.update({
+        where: { id: record.id },
+        data: { usedAt: new Date()},
+    });
+
+    if(!user.is_verified){
+        await prisma.user.update({
+            where: { id: user.id },
+            data: { is_verified: true},
+        });
+    }
+
+    //set issue accesToken for 7 days
+    const accessSecret = process.env.JWT_ACCESS_SECRET;
+    if(!accessSecret){
+        throw new Error("JWT_ACCESS_SECRET not set in env");
+    }
+    
+    const accessToken = jwt.sign(
+        { sub: user.id, email: user.email, role: user.role },
+        accessSecret,
+        { expiresIn: "7d" }
+    );
+
+    return{
+        ok: true as const,
+        accessToken,
+        user: {
+            id: user.id,
+            full_name: user.full_name,
+            email: user.email,
+            is_verified: true,
+            role: user.role,
+        },
+    };
+}

--- a/src/services/cloudinary.service.ts
+++ b/src/services/cloudinary.service.ts
@@ -1,0 +1,200 @@
+import { v2 as cloudinary, UploadApiOptions } from 'cloudinary';
+import { logger } from '../utils/logger';
+
+export interface CloudinaryUploadResult {
+  publicId: string;
+  url: string;
+  secureUrl: string;
+  width: number;
+  height: number;
+  format: string;
+  bytes: number;
+}
+
+export interface CloudinaryDeleteResult {
+  result: string;
+  deletedCount: number;
+}
+
+export class CloudinaryService {
+  constructor() {
+    // Configure Cloudinary
+    cloudinary.config({
+        cloud_name: process.env.CLOUDINARY_CLOUD_NAME || '',
+        api_key: process.env.CLOUDINARY_API_KEY || '',
+        api_secret: process.env.CLOUDINARY_API_SECRET || '',
+    });
+
+    logger.info('Cloudinary service initialized');
+  }
+
+  /**
+   * Upload image to Cloudinary
+   */
+  async uploadImage(
+    imageBuffer: Buffer,
+    options: {
+      folder?: string;
+      publicId?: string;
+      transformation?: any[];
+      tags?: string[];
+    } = {}
+  ): Promise<CloudinaryUploadResult> {
+    try {
+      const uploadOptions: UploadApiOptions = {
+        resource_type: 'image',
+        folder: options.folder || 'allertify',
+        ...(options.publicId && { public_id: options.publicId }),
+        transformation: options.transformation || [
+          { quality: 'auto:good' },
+          { fetch_format: 'auto' }
+        ],
+        tags: options.tags || ['allertify', 'food-safety'],
+        overwrite: true,
+      };
+
+      // Convert buffer to base64 string
+      const base64Image = `data:image/jpeg;base64,${imageBuffer.toString('base64')}`;
+
+      const result = await new Promise<CloudinaryUploadResult>((resolve, reject) => {
+        cloudinary.uploader.upload_stream(
+          uploadOptions ,
+          (error, result) => {
+            if (error) {
+              reject(error as Error);
+            } else if (result) {
+              resolve({
+                publicId: result.public_id,
+                url: result.url,
+                secureUrl: result.secure_url,
+                width: result.width || 0,
+                height: result.height || 0,
+                format: result.format || '',
+                bytes: result.bytes || 0,
+              });
+            } else {
+              reject(new Error('Upload failed with no result'));
+            }
+          }
+        ).end(imageBuffer);
+      });
+
+      logger.info(`Image uploaded successfully: ${result.publicId}`);
+      return result;
+
+    } catch (error) {
+      logger.error('Error uploading image to Cloudinary:', error);
+      throw new Error(`Failed to upload image: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  /**
+   * Upload image from URL
+   */
+  async uploadImageFromUrl(
+    imageUrl: string,
+    options: {
+      folder?: string;
+      publicId?: string;
+      transformation?: any[];
+      tags?: string[];
+    } = {}
+  ): Promise<CloudinaryUploadResult> {
+    try {
+      const uploadOptions: UploadApiOptions = {
+        resource_type: 'image',
+        folder: options.folder || 'allertify',
+        ...(options.publicId && { public_id: options.publicId }),
+        transformation: options.transformation || [
+          { quality: 'auto:good' },
+          { fetch_format: 'auto' }
+        ],
+        tags: options.tags || ['allertify', 'food-safety'],
+        overwrite: true,
+      };
+
+      const result = await cloudinary.uploader.upload(imageUrl, uploadOptions);
+
+      const uploadResult: CloudinaryUploadResult = {
+        publicId: result.public_id,
+        url: result.url,
+        secureUrl: result.secure_url,
+        width: result.width || 0,
+        height: result.height || 0,
+        format: result.format || '',
+        bytes: result.bytes || 0,
+      };
+
+      logger.info(`Image uploaded from URL successfully: ${uploadResult.publicId}`);
+      return uploadResult;
+
+    } catch (error) {
+      logger.error('Error uploading image from URL to Cloudinary:', error);
+      throw new Error(`Failed to upload image from URL: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  /**
+   * Delete image from Cloudinary
+   */
+  async deleteImage(publicId: string): Promise<CloudinaryDeleteResult> {
+    try {
+      const result = await cloudinary.uploader.destroy(publicId);
+      
+      logger.info(`Image deleted successfully: ${publicId}`);
+      return {
+        result: result.result,
+        deletedCount: result.deleted_count || 0,
+      };
+
+    } catch (error) {
+      logger.error('Error deleting image from Cloudinary:', error);
+      throw new Error(`Failed to delete image: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  /**
+   * Get image information
+   */
+  async getImageInfo(publicId: string) {
+    try {
+      const result = await cloudinary.api.resource(publicId);
+      return result;
+    } catch (error) {
+      logger.error('Error getting image info from Cloudinary:', error);
+      throw new Error(`Failed to get image info: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  /**
+   * Generate optimized image URL with transformations
+   */
+  generateOptimizedUrl(
+    publicId: string,
+    transformations: any[] = []
+  ): string {
+    const defaultTransformations = [
+      { quality: 'auto:good' },
+      { fetch_format: 'auto' },
+      { width: 800, height: 600, crop: 'limit' }
+    ];
+
+    const allTransformations = [...defaultTransformations, ...transformations];
+    
+    return cloudinary.url(publicId, {
+      transformation: allTransformations,
+      secure: true,
+    });
+  }
+
+  /**
+   * Check if Cloudinary is properly configured
+   */
+  isConfigured(): boolean {
+    return !!(process.env.CLOUDINARY_CLOUD_NAME && 
+              process.env.CLOUDINARY_API_KEY && 
+              process.env.CLOUDINARY_API_SECRET);
+  }
+}
+
+export default new CloudinaryService();

--- a/src/services/product.service.ts
+++ b/src/services/product.service.ts
@@ -1,0 +1,242 @@
+import { PrismaClient } from '@prisma/client';
+import axios from 'axios';
+
+const prisma = new PrismaClient();
+
+interface OpenFoodFactsResponse {
+  status: number;
+  status_verbose: string;
+  product?: {
+    product_name?: string;
+    brands?: string;
+    image_url?: string;
+    ingredients_text?: string;
+    nutriments?: {
+      'nutrition-score-fr'?: number;
+    };
+  };
+}
+
+export class ProductService {
+  /**
+   * Mencari produk berdasarkan barcode di database lokal,
+   * jika tidak ada maka fetch dari Open Food Facts API
+   */
+  async findOrCreateProductByBarcode(barcode: string) {
+    try {
+      // 1. Coba cari produk di database lokal
+      const existingProduct = await prisma.product.findUnique({
+        where: { barcode }
+      });
+
+      if (existingProduct) {
+        return existingProduct;
+      }
+
+      // 2. Jika tidak ditemukan, panggil Open Food Facts API
+      const response = await axios.get<OpenFoodFactsResponse>(
+        `https://world.openfoodfacts.org/api/v2/product/${barcode}.json`,
+        {
+          timeout: 10000, 
+          headers: {
+            'User-Agent': 'Allertify/1.0.0 (https://allertify.com)'
+          }
+        }
+      );
+
+      // 3. Validasi respons API
+      if (response.data.status !== 1 || !response.data.product) {
+        throw new Error(`Product with barcode ${barcode} not found in Open Food Facts`);
+      }
+
+      const productData = response.data.product;
+      console.log(
+        productData
+      )
+
+      // 4. Ekstrak data yang relevan
+      const productName = productData.product_name || 'Unknown Product';
+      const brand = productData.brands || '';
+      const imageUrl = productData.image_url || '';
+      const ingredients = productData.ingredients_text || '';
+      const nutritionalScore = productData.nutriments?.['nutrition-score-fr']?.toString() || 'N/A';
+
+      // 5. Buat entri baru di database
+      const newProduct = await prisma.product.create({
+        data: {
+          barcode,
+          name: productName,
+          image_url: imageUrl,
+          nutritional_score: nutritionalScore,
+          ingredients: ingredients
+        }
+      });
+
+      return newProduct;
+
+    } catch (error: unknown) {
+      // Enhanced error handling
+      if (axios.isAxiosError(error)) {
+        if (error.response?.status === 404) {
+          throw new Error(`Product with barcode ${barcode} not found in Open Food Facts database`);
+        }
+        if (error.code === 'ECONNABORTED') {
+          throw new Error('Request to Open Food Facts API timed out');
+        }
+        throw new Error(`Open Food Facts API error: ${error.message}`);
+      }
+      
+      if (error instanceof Error) {
+        throw error;
+      }
+      
+      throw new Error('Unknown error occurred while fetching product data');
+    }
+  }
+
+  /**
+   * Mencari produk berdasarkan ID
+   */
+  async findProductById(id: number) {
+    try {
+      const product = await prisma.product.findUnique({
+        where: { id }
+      });
+
+      if (!product) {
+        throw new Error(`Product with ID ${id} not found`);
+      }
+
+      return product;
+    } catch (error) {
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error('Unknown error occurred while fetching product');
+    }
+  }
+
+  /**
+   * Update produk (untuk refresh data dari Open Food Facts)
+   */
+  async updateProduct(id: number, data: Partial<{
+    name: string;
+    image_url: string;
+    nutritional_score: string;
+    ingredients: string;
+  }>) {
+    try {
+      const updatedProduct = await prisma.product.update({
+        where: { id },
+        data
+      });
+
+      return updatedProduct;
+    } catch (error) {
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error('Unknown error occurred while updating product');
+    }
+  }
+
+  /**
+   * Buat produk minimal untuk image scan
+   */
+  async createMinimalProduct(imageUrl: string) {
+    try {
+      const product = await prisma.product.create({
+        data: {
+          barcode: `IMG_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`, 
+          name: 'Product from Image Scan',
+          image_url: imageUrl,
+          nutritional_score: 'N/A',
+          ingredients: 'Extracted from image', 
+        }
+      });
+
+      return product;
+    } catch (error) {
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error('Unknown error occurred while creating minimal product');
+    }
+  }
+
+  /**
+   * Mencari atau buat produk berdasarkan nama
+   */
+  async findOrCreateProductByName(
+    name: string, 
+    options?: {
+      ingredients?: string;
+      barcode?: string;
+      imageUrl?: string;
+    }
+  ) {
+    try {
+      // Coba cari produk dengan nama yang sama
+      const existingProduct = await prisma.product.findFirst({
+        where: { 
+          name: {
+            contains: name,
+            mode: 'insensitive'
+          }
+        }
+      });
+
+      if (existingProduct) {
+        // Update existing product jika ada data baru
+        if (options?.ingredients && existingProduct.ingredients === 'Product created from name') {
+          await this.updateProduct(existingProduct.id, { ingredients: options.ingredients });
+          existingProduct.ingredients = options.ingredients;
+        }
+        if (options?.imageUrl && !existingProduct.image_url) {
+          await this.updateProductImage(existingProduct.id, options.imageUrl);
+          existingProduct.image_url = options.imageUrl;
+        }
+        return existingProduct;
+      }
+
+      // Jika tidak ada, buat produk baru dengan data yang lebih baik
+      const product = await prisma.product.create({
+        data: {
+          barcode: options?.barcode || `NAME_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+          name: name,
+          image_url: options?.imageUrl || '',
+          nutritional_score: 'N/A',
+          ingredients: options?.ingredients || 'Product created from name',
+        }
+      });
+
+      return product;
+    } catch (error) {
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error('Unknown error occurred while finding or creating product by name');
+    }
+  }
+
+  /**
+   * Update image URL produk
+   */
+  async updateProductImage(id: number, imageUrl: string) {
+    try {
+      const updatedProduct = await prisma.product.update({
+        where: { id },
+        data: { image_url: imageUrl }
+      });
+
+      return updatedProduct;
+    } catch (error) {
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error('Unknown error occurred while updating product image');
+    }
+  }
+}
+
+export default new ProductService();

--- a/src/services/scan-limit.service.ts
+++ b/src/services/scan-limit.service.ts
@@ -1,0 +1,178 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export interface DailyScanLimit {
+  userId: number;
+  currentUsage: number;
+  dailyLimit: number;
+  remainingScans: number;
+  isLimitExceeded: boolean;
+}
+
+export class ScanLimitService {
+  /**
+   * Mendapatkan daily scan limit untuk user berdasarkan tier plan
+   */
+  async getUserDailyScanLimit(userId: number): Promise<DailyScanLimit> {
+    try {
+      // Ambil subscription aktif user
+      const activeSubscription = await prisma.subscription.findFirst({
+        where: {
+          user_id: userId,
+          status: 'active',
+          end_date: {
+            gte: new Date()
+          }
+        },
+        include: {
+          tier_plan: true
+        }
+      });
+
+      // Default limit untuk user tanpa subscription (basic plan)
+      let dailyLimit = 100; // Basic plan: 5 scans per day
+      
+      if (activeSubscription) {
+        dailyLimit = activeSubscription.tier_plan.scan_count_limit;
+      }
+
+      // Ambil usage hari ini
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      
+      const dailyUsage = await prisma.daily_scan_usage.findUnique({
+        where: {
+          user_id_usage_date: {
+            user_id: userId,
+            usage_date: today
+          }
+        }
+      });
+
+      const currentUsage = dailyUsage?.scan_count || 0;
+      const remainingScans = Math.max(0, dailyLimit - currentUsage);
+      const isLimitExceeded = currentUsage >= dailyLimit;
+
+      return {
+        userId,
+        currentUsage,
+        dailyLimit,
+        remainingScans,
+        isLimitExceeded
+      };
+
+    } catch (error) {
+      console.error('Error getting user daily scan limit:', error);
+      throw new Error('Failed to get daily scan limit');
+    }
+  }
+
+  /**
+   * Increment daily scan usage untuk user
+   */
+  async incrementDailyScanUsage(userId: number): Promise<void> {
+    try {
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
+      // Upsert daily usage record
+      await prisma.daily_scan_usage.upsert({
+        where: {
+          user_id_usage_date: {
+            user_id: userId,
+            usage_date: today
+          }
+        },
+        update: {
+          scan_count: {
+            increment: 1
+          }
+        },
+        create: {
+          user_id: userId,
+          usage_date: today,
+          scan_count: 1
+        }
+      });
+
+    } catch (error) {
+      console.error('Error incrementing daily scan usage:', error);
+      throw new Error('Failed to increment daily scan usage');
+    }
+  }
+
+  /**
+   * Check apakah user masih bisa scan hari ini
+   */
+  async canUserScanToday(userId: number): Promise<{ canScan: boolean; remainingScans: number; dailyLimit: number }> {
+    try {
+      const limitInfo = await this.getUserDailyScanLimit(userId);
+      
+      return {
+        canScan: !limitInfo.isLimitExceeded,
+        remainingScans: limitInfo.remainingScans,
+        dailyLimit: limitInfo.dailyLimit
+      };
+    } catch (error) {
+      console.error('Error checking if user can scan:', error);
+      // Default: allow scan jika ada error
+      return {
+        canScan: true,
+        remainingScans: 5,
+        dailyLimit: 5
+      };
+    }
+  }
+
+  /**
+   * Reset daily usage untuk testing/development
+   */
+  async resetDailyUsage(userId: number): Promise<void> {
+    try {
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
+      await prisma.daily_scan_usage.deleteMany({
+        where: {
+          user_id: userId,
+          usage_date: today
+        }
+      });
+
+      console.log(`✅ Daily usage reset for user ${userId}`);
+    } catch (error) {
+      console.error('Error resetting daily usage:', error);
+    }
+  }
+
+  /**
+   * Get usage history untuk user (7 hari terakhir)
+   */
+  async getUserUsageHistory(userId: number, days: number = 7): Promise<any[]> {
+    try {
+      const startDate = new Date();
+      startDate.setDate(startDate.getDate() - days);
+      startDate.setHours(0, 0, 0, 0);
+
+      const usageHistory = await prisma.daily_scan_usage.findMany({
+        where: {
+          user_id: userId,
+          usage_date: {
+            gte: startDate
+          }
+        },
+        orderBy: {
+          usage_date: 'desc'
+        }
+      });
+
+      return usageHistory;
+    } catch (error) {
+      console.error('Error getting usage history:', error);
+      return [];
+    }
+  }
+}
+
+export default new ScanLimitService();

--- a/src/services/scan.service.ts
+++ b/src/services/scan.service.ts
@@ -1,0 +1,427 @@
+import { PrismaClient } from '@prisma/client';
+import productService from './product.service';
+import aiService, { AIEvaluation } from './ai.service';
+import scanLimitService from './scan-limit.service';
+import cloudinaryService from './cloudinary.service';
+
+const prisma = new PrismaClient();
+
+export interface ScanResult {
+  id: number;
+  userId: number;
+  productId: number;
+  scanDate: Date;
+  riskLevel: string;
+  riskExplanation: string | null;
+  matchedAllergens: string | null;
+  isSaved: boolean;
+  product: {
+    id: number;
+    barcode: string;
+    name: string;
+    imageUrl: string;
+    ingredients: string;
+  };
+  scanLimit?: {
+    remainingScans: number;
+    dailyLimit: number;
+  };
+}
+
+export class ScanService {
+  /**
+   * Memproses scan barcode produk
+   */
+  async processBarcodeScan(barcode: string, userId: number): Promise<ScanResult> {
+    try {
+      // 1. Check daily scan limit
+      const canScan = await scanLimitService.canUserScanToday(userId);
+      if (!canScan.canScan) {
+        throw new Error(`Daily scan limit exceeded. You have used ${canScan.dailyLimit} scans today. Upgrade your plan for more scans.`);
+      }
+
+      // 2. Cari atau buat produk berdasarkan barcode
+      const product = await productService.findOrCreateProductByBarcode(barcode);
+
+      // 3. Ambil daftar alergi pengguna dari database
+      const userAllergies = await this.getUserAllergies(userId);
+
+      // 4. Analisis bahan menggunakan AI
+      const aiAnalysis = await aiService.analyzeIngredientsWithContext(
+        product.ingredients,
+        userAllergies,
+        {
+          productName: product.name,
+          brand: '', 
+        }
+      );
+
+      // 5. Simpan hasil scan ke database
+      const scanResult = await prisma.product_scan.create({
+        data: {
+          user_id: userId,
+          product_id: product.id,
+          scan_date: new Date(),
+          risk_level: aiAnalysis.riskLevel,
+          risk_explanation: aiAnalysis.reasoning,
+          matched_allergens: aiAnalysis.matchedAllergens.length > 0 
+            ? aiAnalysis.matchedAllergens.join(', ') 
+            : null,
+          is_saved: false, 
+        },
+        include: {
+          product: true,
+        }
+      });
+
+      // 6. Increment daily scan usage
+      await scanLimitService.incrementDailyScanUsage(userId);
+
+      // 7. Get updated scan limit info
+      const updatedLimitInfo = await scanLimitService.getUserDailyScanLimit(userId);
+
+      // 8. Transform dan return hasil
+      const result = this.transformScanResult(scanResult);
+      result.scanLimit = {
+        remainingScans: updatedLimitInfo.remainingScans,
+        dailyLimit: updatedLimitInfo.dailyLimit
+      };
+
+      return result;
+
+    } catch (error) {
+      console.error('Error in processBarcodeScan:', error);
+      
+      if (error instanceof Error) {
+        throw new Error(`Barcode scan failed: ${error.message}`);
+      }
+      
+      throw new Error('Unknown error occurred during barcode scan');
+    }
+  }
+
+  /**
+   * Memproses scan gambar produk (OCR fallback)
+   */
+  async processImageScan(
+    imageUrl: string, 
+    userId: number, 
+    productId?: number
+  ): Promise<ScanResult> {
+    try {
+      // 1. Check daily scan limit
+      const canScan = await scanLimitService.canUserScanToday(userId);
+      if (!canScan.canScan) {
+        throw new Error(`Daily scan limit exceeded. You have used ${canScan.dailyLimit} scans today. Upgrade your plan for more scans.`);
+      }
+
+      // 2. Ambil daftar alergi pengguna
+      const userAllergies = await this.getUserAllergies(userId);
+
+      // 3. Analisis gambar menggunakan AI
+      const aiAnalysis = await aiService.analyzeProductImage(imageUrl, userAllergies);
+
+      // 4. Tentukan produk yang akan digunakan
+      let product;
+      if (productId) {
+        // Jika productId disediakan, gunakan produk yang sudah ada
+        product = await productService.findProductById(productId);
+      } else {
+        // Jika tidak ada productId, buat produk baru dengan data minimal
+        product = await productService.createMinimalProduct(imageUrl);
+      }
+
+      // 5. Simpan hasil scan ke database
+      const scanResult = await prisma.product_scan.create({
+        data: {
+          user_id: userId,
+          product_id: product.id,
+          scan_date: new Date(),
+          risk_level: aiAnalysis.riskLevel,
+          risk_explanation: aiAnalysis.reasoning,
+          matched_allergens: aiAnalysis.matchedAllergens.length > 0 
+            ? aiAnalysis.matchedAllergens.join(', ') 
+            : null,
+          is_saved: false,
+        },
+        include: {
+          product: true,
+        }
+      });
+
+      // 6. Increment daily scan usage
+      await scanLimitService.incrementDailyScanUsage(userId);
+
+      // 7. Get updated scan limit info
+      const updatedLimitInfo = await scanLimitService.getUserDailyScanLimit(userId);
+
+      // 8. Transform dan return hasil
+      const result = this.transformScanResult(scanResult);
+      result.scanLimit = {
+        remainingScans: updatedLimitInfo.remainingScans,
+        dailyLimit: updatedLimitInfo.dailyLimit
+      };
+
+      return result;
+
+    } catch (error) {
+      console.error('Error in processImageScan:', error);
+      
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error('Unknown error occurred while processing image scan');
+    }
+  }
+
+  /**
+   * Menyimpan hasil scan (toggle save status)
+   */
+  async toggleSaveScan(scanId: number, userId: number): Promise<ScanResult> {
+    try {
+      // Verify ownership
+      const existingScan = await prisma.product_scan.findFirst({
+        where: {
+          id: scanId,
+          user_id: userId,
+        }
+      });
+
+      if (!existingScan) {
+        throw new Error('Scan not found or access denied');
+      }
+
+      // Toggle save status
+      const updatedScan = await prisma.product_scan.update({
+        where: { id: scanId },
+        data: { is_saved: !existingScan.is_saved },
+        include: {
+          product: true,
+        }
+      });
+
+      return this.transformScanResult(updatedScan);
+
+    } catch (error) {
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error('Unknown error occurred while toggling scan save status');
+    }
+  }
+
+  /**
+   * Mendapatkan riwayat scan pengguna
+   */
+  async getUserScanHistory(
+    userId: number, 
+    options: {
+      limit?: number;
+      offset?: number;
+      savedOnly?: boolean;
+    } = {}
+  ): Promise<ScanResult[]> {
+    try {
+      const { limit = 20, offset = 0, savedOnly = false } = options;
+
+      const scans = await prisma.product_scan.findMany({
+        where: {
+          user_id: userId,
+          ...(savedOnly && { is_saved: true }),
+        },
+        include: {
+          product: true,
+        },
+        orderBy: {
+          scan_date: 'desc',
+        },
+        take: limit,
+        skip: offset,
+      });
+
+      return scans.map(scan => this.transformScanResult(scan));
+
+    } catch (error) {
+      console.error('Error in getUserScanHistory:', error);
+      
+      if (error instanceof Error) {
+        throw new Error(`Failed to get scan history: ${error.message}`);
+      }
+      
+      throw new Error('Unknown error occurred while fetching scan history');
+    }
+  }
+
+  /**
+   * Helper: Mendapatkan daftar alergi pengguna
+   */
+  private async getUserAllergies(userId: number): Promise<string[]> {
+    try {
+      // Jika bypass auth aktif, return hardcoded allergens
+      if (process.env.BYPASS_AUTH === 'true') {
+        const hardcodedAllergens = process.env.HARDCODED_ALLERGENS 
+          ? process.env.HARDCODED_ALLERGENS.split(',').map(a => a.trim())
+          : ['gluten', 'lactose', 'nuts', 'shellfish', 'eggs'];
+        
+        console.log('🔓 Using hardcoded allergens:', hardcodedAllergens);
+        return hardcodedAllergens;
+      }
+
+      // Normal flow: query database
+      const userAllergies = await prisma.user_allergen.findMany({
+        where: { user_id: userId },
+        include: {
+          allergen: true,
+        }
+      });
+
+      return userAllergies.map(ua => ua.allergen.name);
+
+    } catch (error) {
+      console.error('Error fetching user allergies:', error);
+      // Return empty array if error, so scan can continue
+      return [];
+    }
+  }
+
+  /**
+   * Memproses upload gambar produk untuk analisis alergi
+   */
+  async processImageUpload(
+    imageBuffer: Buffer,
+    userId: number,
+    productName?: string
+  ): Promise<ScanResult> {
+    try {
+      // 1. Check daily scan limit
+      const canScan = await scanLimitService.canUserScanToday(userId);
+      if (!canScan.canScan) {
+        throw new Error(`Daily scan limit exceeded. You have used ${canScan.dailyLimit} scans today. Upgrade your plan for more scans.`);
+      }
+
+      // 2. Upload image to Cloudinary
+      if (!cloudinaryService.isConfigured()) {
+        throw new Error('Cloudinary service is not configured. Please check environment variables.');
+      }
+
+      const uploadResult = await cloudinaryService.uploadImage(imageBuffer, {
+        folder: 'allertify/products',
+        tags: ['product-scan', 'allergen-analysis']
+      });
+
+      // 3. Ambil daftar alergi pengguna dari database
+      const userAllergies = await this.getUserAllergies(userId);
+
+      // 4. Analisis gambar menggunakan AI Vision
+      const aiAnalysis = await aiService.analyzeUploadedImage(
+        uploadResult.secureUrl,
+        userAllergies
+      );
+
+      // 5. Buat atau update produk berdasarkan analisis gambar
+      let product;
+      
+      // Extract product info dari AI analysis jika tersedia
+      const productInfo = this.extractProductInfoFromAI(aiAnalysis);
+      
+      if (productName) {
+        // Jika ada nama produk, cari atau buat produk dengan data AI
+        const options: any = { imageUrl: uploadResult.secureUrl };
+        if (productInfo.ingredients) options.ingredients = productInfo.ingredients;
+        if (productInfo.barcode) options.barcode = productInfo.barcode;
+        
+        product = await productService.findOrCreateProductByName(productName, options);
+      } else {
+        // Jika tidak ada nama, gunakan nama dari AI atau default
+        const productNameFromAI = productInfo.name || 'Product from Image Scan';
+        const options: any = { imageUrl: uploadResult.secureUrl };
+        if (productInfo.ingredients) options.ingredients = productInfo.ingredients;
+        if (productInfo.barcode) options.barcode = productInfo.barcode;
+        
+        product = await productService.findOrCreateProductByName(productNameFromAI, options);
+      }
+
+      // 6. Simpan hasil scan ke database
+      const scanResult = await prisma.product_scan.create({
+        data: {
+          user_id: userId,
+          product_id: product.id,
+          scan_date: new Date(),
+          risk_level: aiAnalysis.riskLevel,
+          risk_explanation: aiAnalysis.reasoning,
+          matched_allergens: aiAnalysis.matchedAllergens.length > 0 
+            ? aiAnalysis.matchedAllergens.join(', ') 
+            : null,
+          is_saved: false,
+        },
+        include: {
+          product: true,
+        }
+      });
+
+      // 7. Increment daily scan usage
+      await scanLimitService.incrementDailyScanUsage(userId);
+
+      // 8. Get updated scan limit info
+      const updatedLimitInfo = await scanLimitService.getUserDailyScanLimit(userId);
+
+      // 9. Transform dan return hasil
+      const result = this.transformScanResult(scanResult);
+      result.scanLimit = {
+        remainingScans: updatedLimitInfo.remainingScans,
+        dailyLimit: updatedLimitInfo.dailyLimit
+      };
+
+      return result;
+
+    } catch (error) {
+      console.error('Error in processImageUpload:', error);
+      
+      if (error instanceof Error) {
+        throw new Error(`Image upload scan failed: ${error.message}`);
+      }
+      
+      throw new Error('Unknown error occurred during image upload scan');
+    }
+  }
+
+  /**
+   * Helper: Extract product info dari AI analysis
+   */
+  private extractProductInfoFromAI(aiAnalysis: any) {
+    // TODO: Implement AI response parsing untuk extract product info
+ 
+    return {
+      name: undefined,
+      ingredients: undefined,
+      barcode: undefined
+    };
+  }
+
+  /**
+   * Helper: Transform database result ke format yang konsisten
+   */
+  private transformScanResult(scanData: any): ScanResult {
+    return {
+      id: scanData.id,
+      userId: scanData.user_id,
+      productId: scanData.product_id,
+      scanDate: scanData.scan_date,
+      riskLevel: scanData.risk_level,
+      riskExplanation: scanData.risk_explanation,
+      matchedAllergens: scanData.matched_allergens,
+      isSaved: scanData.is_saved,
+      product: {
+        id: scanData.product.id,
+        barcode: scanData.product.barcode,
+        name: scanData.product.name,
+        imageUrl: scanData.product.image_url,
+        ingredients: scanData.product.ingredients,
+      }
+    };
+  }
+}
+
+export default new ScanService();
+
+

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,32 @@
+import winston from 'winston';
+
+const logger = winston.createLogger({
+  level: process.env.LOG_LEVEL || 'info',
+  format: winston.format.combine(
+    winston.format.timestamp({
+      format: 'YYYY-MM-DD HH:mm:ss'
+    }),
+    winston.format.errors({ stack: true }),
+    winston.format.json()
+  ),
+  defaultMeta: { service: 'allertify-backend' },
+  transports: [
+    new winston.transports.File({ filename: 'logs/error.log', level: 'error' }),
+    new winston.transports.File({ filename: 'logs/combined.log' }),
+  ],
+});
+
+// not to production env
+if (process.env.NODE_ENV !== 'production') {
+  logger.add(new winston.transports.Console({
+    format: winston.format.combine(
+      winston.format.colorize(),
+      winston.format.simple(),
+      winston.format.printf(({ timestamp, level, message, ...meta }) => {
+        return `${timestamp} [${level}]: ${message} ${Object.keys(meta).length ? JSON.stringify(meta, null, 2) : ''}`;
+      })
+    )
+  }));
+}
+
+export { logger };

--- a/src/utils/mailer.ts
+++ b/src/utils/mailer.ts
@@ -1,0 +1,26 @@
+import { string } from "joi";
+import nodemailer from "nodemailer";
+
+export async function sendOTPEmail(to: string, otp: string){
+    let transporter = nodemailer.createTransport({
+        service: "gmail",
+        secure: true,
+        auth: {
+            user: process.env.SMTP_USER,
+            pass: process.env.SMTP_PASS,
+        },
+    });
+
+    let info = await transporter.sendMail({
+        from: process.env.SMTP_FROM, //sender
+        to: to, //reciever
+        subject: "OTP Verification Code",
+        text: `Hi there,
+Your verification code for Allertify is:${otp}
+This code is valid for 5 minutes. 
+Please do not share this code with anyone to keep your account secure.
+Thanks,
+The Allertify Team`,
+    });
+    console.log("Code has been sent: %s", info.response);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     // See also https://aka.ms/tsconfig/module
     "module": "nodenext",
     "target": "esnext",
-    "types": [],
+    "types": ["node"],
     // For nodejs:
     // "lib": ["esnext"],
     // "types": ["node"],
@@ -36,11 +36,18 @@
 
     // Recommended Options
     "strict": true,
-    "jsx": "react-jsx",
     "verbatimModuleSyntax": false,
     "isolatedModules": true,
     "noUncheckedSideEffectImports": true,
     "moduleDetection": "force",
     "skipLibCheck": true,
-  }
+  },
+  "include": [
+    "src/**/*"                
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }


### PR DESCRIPTION
## What I Did
- Implemented Login endpoint (/api/v1/auth/login)
- Added login service logic using:
       - Prisma to find user by email
       - argon2 to verify hashed password
       - JWT (jsonwebtoken) to issue access token valid for 7 days
- Integrated input validation using Joi schema (email + password)
- Ensured only verified users can log in (is_verified = true)
- Added proper error handling (wrong email, invalid password, unverified account)
- Tested login flow using Postman

## How to Test
- Open postman, create a new request in existing collection
- Change the method to POST, and fill the table with http://localhost:3000/api/v1/auth/register
- Fill the body change first to raw and json type, fill withyour testing information
- Then click send, see the result. OTP will send to your email testing
- You can do the same for register for resend OTP
- Next, you duplicate the response, change the table with http://localhost:3000/api/v1/auth/otp
- Fill the body raw json with your register information (email) and OTP you get
- Then, duplicate again the response, change the table with http://localhost:3000/api/v1/auth/login
- Fill the body raw json with email and passoword you registered